### PR TITLE
refactor: Move logic for loading an RMS project in docker

### DIFF
--- a/aps/api/app.py
+++ b/aps/api/app.py
@@ -37,5 +37,22 @@ def favicon():
     return ''
 
 
+if __name__ == 'app':
+    # That is on when flask loads the app
+    try:
+        project
+    except NameError:
+        if 'RMS_PROJECT_PATH' in environ:
+            # Ensure "project" is available as a global variable
+            # similar to what ui.py expects
+            import roxar
+
+            __builtins__ = globals()['__builtins__']  # load the module
+            if 'project' not in __builtins__:
+                __builtins__['project'] = roxar.Project.open(environ['RMS_PROJECT_PATH'])
+        else:
+            raise RuntimeError('No project available, and RMS_PROJECT_PATH is not set')
+
+
 if __name__ == '__main__':
     main()

--- a/aps/api/ui.py
+++ b/aps/api/ui.py
@@ -3,19 +3,6 @@ from aps.utils.roxar.rms_project_data import RMSData
 import roxar.rms
 
 
-try:
-    # When running in RMS, the current project should be available as `project` in the global scope
-    project
-except NameError:
-    import os
-    if 'RMS_PROJECT_PATH' in os.environ:
-        # Ensure "project" is available as a global variable
-        # similar to what ui.py expects
-        project = roxar.Project.open(os.environ['RMS_PROJECT_PATH'])
-    else:
-        raise RuntimeError('No project available, and RMS_PROJECT_PATH is not set')
-
-
 def call(method_name, *args, **kwargs):
     # TODO: Separate rms methods from 'static' methods
     func = getattr(RMSData(roxar, project), method_name)


### PR DESCRIPTION
### Reasons for making this change

It seems RMS does not provide `project` directly in `main.py` / `ui.py`, but gives it when it is used.

This makes sure that the project is only loaded when running from flask


### Related issues

* #4 
