### PR TITLE
fix: Allow user to create FMU grid if it doesn't exist

### DIFF
--- a/gui/src/components/dialogs/JobSettings/FmuSettings.vue
+++ b/gui/src/components/dialogs/JobSettings/FmuSettings.vue
@@ -26,7 +26,7 @@
         <v-col cols="6">
           <hover-helper v-slot="{ isHovering }">
             <floating-tooltip :shown="isHovering" :disabled="hasGrid">
-              <v-autocomplete
+              <v-combobox
                 v-model="_fmuGrid"
                 label="ERT/FMU simulation box grid"
                 :disabled="!hasGrid"


### PR DESCRIPTION
### Reasons for making this change

`<v-autocomplete>` should not be used when the user can select options that are not in the list.
For that, we may use `<v-combobox>`.

The intended functionality here, is to allow the user to create the gird if it does not already exist.


