### PR TITLE
Added optional keyword to add noise to extrapolated values

### DIFF
--- a/aps/rms_jobs/copy_rms_param_to_fmu_grid.py
+++ b/aps/rms_jobs/copy_rms_param_to_fmu_grid.py
@@ -30,7 +30,7 @@ def run(project, **kwargs):
         'debug_level': Debug.VERBOSE,
     }
 
-    run_copy_rms_param_to_ertbox(params)
+    run_copy_rms_param_to_ertbox(params, seed=project.seed)
 
 
 if __name__ == "__main__":

--- a/aps/toolbox/example_scripts/test_resample_properties_from_ertbox1.py
+++ b/aps/toolbox/example_scripts/test_resample_properties_from_ertbox1.py
@@ -39,5 +39,5 @@ params ={
     "ZoneParam": "Zone",
     "ERTBoxGridName": "ERTBOX",
 }
-copy_rms_param_to_ertbox_grid.run(params)
+copy_rms_param_to_ertbox_grid.run(params,project.seed)
 

--- a/aps/toolbox/example_scripts/test_resample_properties_from_ertbox2.py
+++ b/aps/toolbox/example_scripts/test_resample_properties_from_ertbox2.py
@@ -10,5 +10,5 @@ params ={
     "model_file_name": "examples/resample_properties_from_ertbox.yml",
     "debug_level": Debug.VERBOSE,
 }
-copy_rms_param_to_ertbox_grid.run(params)
+copy_rms_param_to_ertbox_grid.run(params, project.seed)
 

--- a/aps/toolbox/example_scripts/test_resample_properties_to_ertbox1.py
+++ b/aps/toolbox/example_scripts/test_resample_properties_to_ertbox1.py
@@ -33,6 +33,7 @@ params ={
     "ERTBoxGridName": "ERTBOX",
     "ExtrapolationMethod": "repeat",
     "SaveActiveParam": True,
+    "AddNoiseToInactive": True,
 }
-copy_rms_param_to_ertbox_grid.run(params)
+copy_rms_param_to_ertbox_grid.run(params, project.seed)
 


### PR DESCRIPTION
### Reasons for making this change

The function to copy grid values for field parameters from geogrid to ERTBOX grid is a step in the workflow
to be able to update petrophysical fields in ERT. Since there is a need for filling in values in all grid cells in the ERTBOX
regardless of the cells are used or not in the geogrid due to the way ERT is currently working, the extrapolation method to fill in values can in some cases fill in the same value for all realizations for some grid cells (e.g. outside the boundary of the active grid cells of the geogrid). To avoid having prior ensemble with grid cells with 0 standard deviation, a workaround is to ensure that this does not happen in the extrapolation. By adding a small noise to extrapolated values, one can avoid 0 standard deviation in any of the grid cells filled in the ERTBOX by the extrapolation.

### Related issues

ERT update (in particular equations for adaptive localisation) will give warnings and errors related to 0 standard deviation of field parameters in the prior ensemble.

Closes: #45

