### PR TITLE
fix: Ensure the install-script works with RedHat base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,11 @@ elif [[ $OS_ID == 'centos' ]]; then
     yum update -y
     yum install -y $@
   }
+elif [[ $OS_ID == 'rhel' ]]; then
+  install () {
+    dnf update -y
+    dnf install -y $@
+  }
 else
   echo "Unsupported OS ($OS_ID)" >/dev/stderr
   exit 1


### PR DESCRIPTION
### Reasons for making this change

CentOS is no longer supported so the "install" script should be updated to work with Red Hat base images.
