### PR TITLE
Get grid conformities directly from RMS

### DIFF
--- a/aps/algorithms/APSModel.py
+++ b/aps/algorithms/APSModel.py
@@ -4,7 +4,6 @@ import collections
 import copy
 import xml.etree.ElementTree as ET
 from typing import List, Optional, Tuple, Union, Dict, TYPE_CHECKING
-from warnings import warn
 
 from aps.algorithms.APSMainFaciesTable import APSMainFaciesTable
 from aps.algorithms.APSZoneModel import APSZoneModel
@@ -690,7 +689,7 @@ class APSModel:
         without putting any data into the data structure.
         """
         if (not use_rms_uncertainty_table) and (not parameter_file_name):
-            raise IOError(f'Expect that a global variable file exists')
+            raise IOError('Expect that a global variable file exists')
         # Read XML model file
         tree = ET.parse(model_file_name)
         root = tree.getroot()
@@ -728,7 +727,7 @@ class APSModel:
 
                 if current_job_name is None:
                     print(
-                        f'NOTE: The APS parameters are not updated when running interactively'
+                        'NOTE: The APS parameters are not updated when running interactively'
                     )
                 else:
                     if len(keywords_defined_for_updating) > 0:
@@ -783,7 +782,7 @@ class APSModel:
             )
 
         # Set new values if keyword in global_variables file and in fmu tag in model file match
-        if (len(keywords_defined_for_updating) > 0) and (keywords_read != None):
+        if (len(keywords_defined_for_updating) > 0) and (keywords_read is not None):
             # Update the list of keywords in the model file with new values from FMU global_variables
             found_an_update = False
             for item in keywords_defined_for_updating:
@@ -800,7 +799,7 @@ class APSModel:
                 print(f'The APS parameters are updated for the job: {current_job_name}')
                 if debug_level >= Debug.VERBOSE:
                     print(
-                        f'   Parameter name                                   Original value   New value'
+                        '   Parameter name                                   Original value   New value'
                     )
             else:
                 # Should never occur
@@ -892,7 +891,7 @@ class APSModel:
                     keywords.append(item)
                 return keywords
 
-            except:
+            except KeyError:
                 # No parameter specified to be updated for the current APS job
                 return None
 
@@ -1594,7 +1593,7 @@ class APSModel:
         # Check if there are (zone_number, region_numbers) in the grid model without any specified APS model.
         if debug_level >= Debug.VERBOSE:
             print(
-                f'-- Check if there are zones with regions without any specified APS model.'
+                '-- Check if there are zones with regions without any specified APS model.'
             )
         list_of_undefined_zone_regions = []
         for zone_number in zone_param.code_names.keys():
@@ -1643,7 +1642,6 @@ class APSModel:
         grid3D = grid_model.get_grid(realisation_number)
         try:
             # Check for RMS14.1 and newer
-            simbox = grid3D.simbox
             # Is RMS14.1 or newer
             simbox_thickness_per_zone = get_simulation_box_thickness(grid3D)
             for key, zone_model in self.__zoneModelTable.items():
@@ -1654,7 +1652,7 @@ class APSModel:
                         f'--- Zone: {zone_number}  Simbox thickness:  {zone_model.sim_box_thickness}'
                     )
                 self.__zoneModelTable[key] = zone_model
-        except:
+        except KeyError:
             # Nothing done for older versions of RMS
             pass
 
@@ -1926,7 +1924,6 @@ class APSModel:
             print(
                 f'      Trend param extrapolation:  {self.__fmu_trend_param_extrapolation}'
             )
-
         if self.__fmu_mode != 'OFF':
             print(
                 f'     Update only residual GRF in ERT: {self.__fmu_use_residual_fields}'

--- a/aps/rms_jobs/copy_rms_param_trend_to_fmu_grid.py
+++ b/aps/rms_jobs/copy_rms_param_trend_to_fmu_grid.py
@@ -19,6 +19,7 @@ from aps.utils.constants.simple import (
 )
 from aps.utils.roxar.grid_model import get_zone_layer_numbering, get_zone_names
 from aps.utils.roxar.progress_bar import APSProgressBar
+from aps.utils.roxar.get_conformity_from_rms import check_grid_layout
 
 
 def get_grid_model(project, grid_model_name: str):
@@ -82,6 +83,12 @@ def get_trend_param_names_from_aps_model(
             continue
         zone_index = zone_number - 1
         zone_name = zone_names[zone_index]
+        check_grid_layout(
+            geo_grid_model_name,
+            zone_number,
+            zone_model.grid_layout,
+            debug_level=debug_level,
+        )
 
         number_layers = number_layers_per_zone[zone_number - 1]
 
@@ -609,7 +616,7 @@ def extrapolate_values_for_zone(
             )
         if add_noise_to_inactive:
             print(
-                f'-- Add random noise to undefined grid cells in ERTBOX on top of the extrapolated values'
+                '-- Add random noise to undefined grid cells in ERTBOX on top of the extrapolated values'
             )
 
     if add_noise_to_inactive:
@@ -723,7 +730,7 @@ def copy_parameters_for_zone(
     elif param_type == 'int':
         param_values_3d_all = ma.masked_all((nx, ny, nz), dtype=np.uint16)
     else:
-        raise ValueError(f"Parameter type must be 'float' or 'int' ")
+        raise ValueError("Parameter type must be 'float' or 'int' ")
     param_values_3d_all[i_indices, j_indices, k_indices] = param_values_active[
         zone_cell_numbers
     ]
@@ -933,7 +940,7 @@ def run(
     debug_level = kwargs['debug_level']
     trend_extrapolation_method = kwargs['extrapolation_method']
     zone_dict, use_rms_param_trend = get_trend_param_names_from_aps_model(
-        project, aps_model, ertbox_grid_model_name, debug_level=Debug.OFF
+        project, aps_model, ertbox_grid_model_name, debug_level=debug_level
     )
 
     # Independent of using custom trends or not we can save active parameter in ertbox

--- a/aps/utils/roxar/get_conformity_from_rms.py
+++ b/aps/utils/roxar/get_conformity_from_rms.py
@@ -1,0 +1,166 @@
+from rmsapi.jobs import Job
+from aps.utils.constants.simple import Conform, Debug
+from typing import Optional
+
+
+def get_conformity(grid_model_name: str, rms_grid_job_name: str) -> tuple[dict, bool]:
+    """Function to get conformity from the grid.
+    Restrictions:
+    - All horizons used are specified to be honored and not sampled.
+    - The zones must be defined with Horizon as reference for both
+      top and base and no Surface is used to define grid layout.
+    - If the two above mentioned criteria is satisfied, it is possible
+      to use the 'ConformalMode' list from rmsapi to get conformity status.
+
+    If restrictions above are not satisfied, the current function will return
+    undefined for the conformity for all zones.
+    """
+    owner_strings = ['Grid models', grid_model_name, 'Grid']
+    type_string = 'Create Grid'
+    name = rms_grid_job_name
+    grid_job = Job.get_job(owner_strings, type_string, name)
+    arguments = grid_job.get_arguments()
+    conformal_mode_list = arguments['ConformalMode']
+    zone_names = arguments['ZoneNames']
+    use_base_surface = arguments['UseBottomSurface']
+    use_top_surface = arguments['UseTopSurface']
+
+    conformity_dict: dict[int, dict] = {}
+    is_defined = True
+    # zone_number starts at 1
+    if len(zone_names) > len(conformal_mode_list):
+        # This indicates that some zone borders are calculated using 'Sample'
+        # and not 'Honor'. In this case the conformal_mode_list no longer
+        # match the modelling zones since sone zones are merged when
+        # defining grid layout.
+        is_defined = False
+        return conformity_dict, is_defined
+
+    for zone_number, zone_name in enumerate(zone_names, start=1):
+        conform_mode = conformal_mode_list[zone_number - 1]
+        use_top_surf = use_top_surface[zone_number - 1]
+        use_base_surf = use_base_surface[zone_number - 1]
+        if use_top_surf or use_base_surf:
+            is_defined = False
+            return {}, is_defined
+        assert conform_mode in [0, 1, 2]
+        if conform_mode == 0:
+            conform = Conform.Proportional
+        elif conform_mode == 1:
+            conform = Conform.TopConform
+        else:
+            conform = Conform.BaseConform
+
+        conformity_dict[zone_number] = {'zone_name': zone_name, 'conformity': conform}
+    return conformity_dict, is_defined
+
+
+def get_job_name(grid_model_name: str) -> Optional[str]:
+    """Get job name for a specified grid model.
+    Return None if no job found , the job name if found
+    and error if multiple job names are found.
+    """
+    owner_strings = ['Grid models', grid_model_name, 'Grid']
+    type_string = 'Create Grid'
+    job_names = Job.get_job_names(owner_strings, type_string)
+    if len(job_names) == 0:
+        return None
+    return job_names
+
+
+def check_grid_layout(
+    grid_model_name,
+    zone_number: int,
+    grid_layout: Conform,
+    aps_job_name: str = None,
+    debug_level: Debug = Debug.OFF,
+) -> None:
+    job_names = get_job_name(grid_model_name)
+    if job_names is None:
+        if debug_level >= Debug.ON:
+            print('Warning: ')
+            print(
+                f"      No automatic grid conformity check for '{grid_model_name}'"
+                f' for zone number {zone_number}.'
+            )
+            print('      This grid is not created by an RMS grid building job.')
+        return
+
+    elif len(job_names) > 1:
+        if debug_level >= Debug.ON:
+            print('Warning:')
+            print(
+                f"        No automatic grid conformity check for '{grid_model_name}'"
+                f' for zone number {zone_number}.'
+            )
+            print('        There exists multiple grid building jobs for this grid.')
+            print('       Cannot know which one to use to check grid conformity.')
+            print('       The jobs are:')
+            print(f'       {job_names}')
+        return
+
+    rms_grid_job_name = job_names[0]
+    conformity_dict, is_defined = get_conformity(grid_model_name, rms_grid_job_name)
+    if not is_defined:
+        if debug_level >= Debug.ON:
+            print('Warning: ')
+            print(
+                f"        No automatic grid conformity check for '{grid_model_name}'."
+            )
+            print('        This type of grid conformity is not implemented.')
+            print(
+                f"        The grid building job  '{rms_grid_job_name}' is using 'Sample'"
+            )
+            print(
+                "        for zone borders or 'Surface' and not 'Horizon' as top and/or base "
+            )
+            print('        reference map.')
+            print(
+                '        You must choose the best of the three possible implemented conformities:'
+            )
+            print("         'Proportional', 'TopConform' or 'BaseConform')")
+            print()
+        return
+
+    zone_conformity_dict = conformity_dict[zone_number]  # Zone number start at 1
+    zone_name = zone_conformity_dict['zone_name']
+    conformity = zone_conformity_dict['conformity']
+    if grid_layout != conformity:
+        if aps_job_name is not None:
+            aps_job_string = f"'APS job '{aps_job_name}'"
+        else:
+            aps_job_string = 'current APS job'
+        raise ValueError(
+            '\n'
+            f"  Specified zone conformity for zone '{zone_name}' is '{grid_layout}'\n"
+            f"  Grid model '{grid_model_name}' has different zone conformity: {conformity}\n"
+            f'  Change conformity setting in {aps_job_string} to match the correct one used in the grid model.'
+        )
+    if debug_level >= Debug.VERY_VERBOSE:
+        print(
+            '--- Specified grid conformity in APS model '
+            f"is consistent with the grid for zone '{zone_name}'"
+        )
+    return
+
+
+if __name__ == '__main__':
+    # A test case
+    grid_model_name = 'GridModelCoarse'
+    aps_job_name = 'APS_job'
+    grid_model = project.grid_models[grid_model_name]
+    zone_numbers = [1, 2, 3]
+    grid_layouts = [
+        Conform.Proportional,
+        Conform.TopConform,
+        Conform.BaseConform,
+    ]
+    for zone_number in zone_numbers:
+        grid_layout = grid_layouts[zone_number - 1]
+        check_grid_layout(
+            grid_model_name,
+            zone_number,
+            grid_layout,
+            aps_job_name=aps_job_name,
+            debug_level=Debug.VERY_VERBOSE,
+        )

--- a/aps/utils/roxar/job.py
+++ b/aps/utils/roxar/job.py
@@ -22,10 +22,11 @@ from aps.utils.roxar.rms_project_data import RMSData
 from aps.utils.aps_config import APSConfig
 from aps.utils.roxar.progress_bar import APSProgressBar
 from aps.utils.check_rms_interactive_or_batch import check_rms_execution_mode
+from aps.utils.roxar.get_conformity_from_rms import check_grid_layout
 
 
 def excepthook(type, value, traceback):
-    print(f'ERROR:')
+    print('ERROR:')
     print(f'Type:  {type.__name__}')
     print(f'{value}')
 
@@ -127,6 +128,14 @@ class JobConfig:
                         f'The zone with code {zone_model.zone_number} does not have any conformity specified. '
                         f'This is required, when running in ERT / AHM.'
                     )
+                else:
+                    check_grid_layout(
+                        aps_model.grid_model_name,
+                        zone_model.zone_number,
+                        zone_model.grid_layout,
+                        aps_job_name=self.roxar.rms.get_running_job_name(),
+                    )
+
         # Check if APS model is consistent with grid model and has only zones defined in grid model
         ok, err_msg = self.check_zones(aps_model)
         if not ok:
@@ -353,7 +362,7 @@ class JobConfig:
             if current_job_name is not None:
                 err_message = f'Current grid model: {aps_model.grid_model_name}  has less number of zones than specified in the APS job: {current_job_name}. '
             else:
-                err_message = f'Current grid model has less number of zones than specified in the APS job.'
+                err_message = 'Current grid model has less number of zones than specified in the APS job.'
 
             if self.run_fmu_workflows:
                 self._config['fmu']['create']['value'] = True


### PR DESCRIPTION
### Reasons for making this change

Today the user have to specify grid conformity for each zone when using the AHM mode in APS. This means the user have to open the grid job that has created the grid chosen in the APS job and check the grid conformity there and specify the same in the APS GUI. To reduce this manual work and reduce possibilities for mismatch, APS plugin can get the conformity for each zone directly from the grid job in RMS.  This can be done by specifying the job name for the grid job that has created the current grid. Another argument for this change is that it is easy to get mismatch between zone conformity settings in the geogrid and the APS model if the geogrid conformity is changed. There are no check of this consistency per today.

A possible solution is then for **interactive use of APS**:

- In Job settings window specify a drop-down field where the user can select which job has been used to create the current grid model. If None is selected (this should be an option), the user will have to specify the conformity per zone as today.
- In the main window display the conformity per zone as read-only settings and not as mutable values in the case a job name is specified where the plugin can find the conformity settings. If no job name is selected, the conformity fields must be selectable as today.
- The reason for having the option not to specify any job is for cases where the geogrid (the grid the APS job has selected) is not created by RMS, but imported or created by a script run in RMS and there does not exist any RMS job that has created the grid.

**Run time use**:
When running APS job, the python code should check consistent settings for the APS zone conformities against the grid if possible. This can be possible if the code knows which job has created the grid.

### Related issues

Per today there are no rmsapi functionality to find which RMS job has created a grid. Interactively this can be done by selecting 'grid'->'task'->'open parent job'  We have asked Aspentech if this functionality can be made available. The conformity could be found automatically without any user interaction at all if the grid was created by a job in RMS if this functionality existed. 


Closes: #59



