### PR TITLE
Use zone parameter's code_names table to set zone number for each zone.

### DIFF
--- a/aps/algorithms/APSModel.py
+++ b/aps/algorithms/APSModel.py
@@ -29,7 +29,11 @@ from aps.utils.xmlUtils import (
     create_node,
 )
 from aps.utils.io import GlobalVariables, write_string_to_file
-from aps.utils.roxar.grid_model import create_zone_parameter, find_defined_cells
+from aps.utils.roxar.grid_model import (
+    create_zone_parameter,
+    find_defined_cells,
+)
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 if TYPE_CHECKING:
     from roxar import Project
@@ -503,17 +507,17 @@ class APSModel:
 
         # Get the number of zones of the current modelling grid if a check to compare
         # the grid model with the specified zones in the APS model is to be done.
-        number_of_zones_in_grid = None
+        zone_mapping = None
         if check_with_grid_model:
             if self.grid_model_name not in project.grid_models:
                 raise ValueError(f'Grid model {self.grid_model_name} does not exist.')
             grid_model = project.grid_models[self.grid_model_name]
             if grid_model.is_empty(project.current_realisation):
                 raise ValueError(f'Grid model {self.grid_model_name} is empty.')
-            zonation = grid_model.get_grid(
-                project.current_realisation
-            ).simbox_indexer.zonation
-            number_of_zones_in_grid = len(zonation.keys())
+            grid = grid_model.get_grid(project.current_realisation)
+            zone_mapping = ZoneMapping(
+                grid_model, grid, real_number=project.current_realisation
+            )
 
         # Read all zones for models specifying main level facies
         # --- ZoneModels ---
@@ -545,13 +549,12 @@ class APSModel:
                 )
             region_number = get_region_number(zone)
 
-            if check_with_grid_model and zone_number > number_of_zones_in_grid:
-                # Skip this zone since it does not exist in grid model
-                print(
-                    f'Warning: Skip zone models with zone_number = {zone_number} due to mismatch with {self.grid_model_name}'
+            if check_with_grid_model and not zone_mapping.is_zone_number_defined(
+                zone_number
+            ):
+                raise ValueError(
+                    f'The zone number {zone_number} is not found in zone parameter: {GridModelConstants.ZONE_NAME} '
                 )
-                self.__zones_removed = True
-                continue
 
             # The model is identified by the combination (zoneNumber, regionNumber)
             zoneModelKey = (zone_number, region_number)
@@ -882,6 +885,8 @@ class APSModel:
         else:
             # YAML file with more general possibility for parameter specification
             aps_dict = GlobalVariables.parse(global_variables_file)
+            if aps_dict is None:
+                return None
 
             # Find the model parameters for the current aps job
             try:
@@ -1633,6 +1638,7 @@ class APSModel:
         simbox thickness for the current realisation of the grid.
         """
         from aps.utils.roxar.grid_model import get_simulation_box_thickness
+        from fmu.tools.rms.zone_mapping import ZoneMapping
 
         if debug_level >= Debug.VERBOSE:
             print(f'-- Get simbox thickness for grid model {self.grid_model_name}')
@@ -1640,10 +1646,13 @@ class APSModel:
         grid_model = project.grid_models[self.grid_model_name]
         realisation_number = project.current_realisation
         grid3D = grid_model.get_grid(realisation_number)
+        zone_mapping = ZoneMapping(grid_model, grid3D, real_number=realisation_number)
         try:
             # Check for RMS14.1 and newer
             # Is RMS14.1 or newer
-            simbox_thickness_per_zone = get_simulation_box_thickness(grid3D)
+            simbox_thickness_per_zone = get_simulation_box_thickness(
+                grid3D, zone_mapping
+            )
             for key, zone_model in self.__zoneModelTable.items():
                 (zone_number, _) = key
                 zone_model.sim_box_thickness = simbox_thickness_per_zone[zone_number]

--- a/aps/algorithms/defineFaciesProbMapDepTrend.py
+++ b/aps/algorithms/defineFaciesProbMapDepTrend.py
@@ -12,6 +12,7 @@ from aps.utils.constants.simple import Debug
 from aps.algorithms.defineFacies import BaseDefineFacies
 from aps.utils.exceptions.xml import MissingKeyword
 from aps.utils.xmlUtils import getIntCommand
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 class DefineFaciesProbMapDep(BaseDefineFacies):
@@ -74,7 +75,7 @@ class DefineFaciesProbMapDep(BaseDefineFacies):
             self._zone_azimuth_values = zone_azimuth_values
             if len(self._zone_azimuth_values) != len(self._selected_zone_numbers):
                 raise ValueError(
-                    f'Number of selected zones must match number of azimuth values'
+                    'Number of selected zones must match number of azimuth values'
                 )
             self._resolution = resolution
 
@@ -95,6 +96,7 @@ class DefineFaciesProbMapDep(BaseDefineFacies):
         grid_model = self.project.grid_models[self.grid_model_name]
         is_shared = grid_model.shared
         grid_3d = grid_model.get_grid(real_number)
+        zone_mapping = ZoneMapping(grid_model, grid_3d, real_number=real_number)
         indexer = grid_3d.simbox_indexer
         dim_i, dim_j, _ = indexer.dimensions
         [zone_values, _] = getDiscrete3DParameterValues(
@@ -114,12 +116,10 @@ class DefineFaciesProbMapDep(BaseDefineFacies):
         stripe_number = np.zeros(len(zone_values), np.float32)
 
         # Go through zone by zone and compute deposition average
-        for idx in range(len(self.selected_zone_numbers)):
-            # selected_zone_numbers have zone numbers starting at 1
-            # zone_index must start at 0
-            zone_index = self.selected_zone_numbers[idx] - 1
+        for ii, zone_number in enumerate(self.selected_zone_numbers):
+            zone_index = zone_mapping.get_zone_index_for_zone_number(zone_number)
             if self.debug_level >= Debug.ON:
-                print('Zone number: ', zone_index + 1)
+                print('- Zone number: ', zone_number)
             if zone_index in indexer.zonation:
                 layer_ranges = indexer.zonation[zone_index]
                 lr = layer_ranges[0]
@@ -130,8 +130,8 @@ class DefineFaciesProbMapDep(BaseDefineFacies):
                 cell_corners = grid_3d.get_cell_corners(cell_nums)
                 cell_centers = grid_3d.get_cell_centers(cell_nums)
 
-                # Normal vector to azimuth
-                az = self.zone_azimuth_values[idx]
+                # Normal vector to azimuth (one for each zone_number)
+                az = self.zone_azimuth_values[ii]
                 alpha = az + 90
                 if alpha > 360:
                     alpha = alpha - 360
@@ -191,15 +191,16 @@ class DefineFaciesProbMapDep(BaseDefineFacies):
         # Write the calculated probabilities for the selected zones to 3D parameter
         # If the 3D parameter exist in advance, only the specified zones will be altered
         # while grid cell values for other zones are unchanged.
-        # selected zone numbers must count from 0 here.
-        selected_zone_numbers_zero_indexed = [
-            znr - 1 for znr in self.selected_zone_numbers
-        ]
+        zone_indices_for_selected_zone_numbers = []
+        for zone_number in self.selected_zone_numbers:
+            zone_index = zone_mapping.get_zone_index_for_zone_number(zone_number)
+            zone_indices_for_selected_zone_numbers.append(zone_index)
+
         set_continuous_3d_parameter_values(
             grid_model,
             'stripeNumber',
             stripe_number,
-            selected_zone_numbers_zero_indexed,
+            zone_indices_for_selected_zone_numbers,
             real_number,
             is_shared=is_shared,
         )
@@ -214,7 +215,7 @@ class DefineFaciesProbMapDep(BaseDefineFacies):
                     grid_model,
                     parameter_name,
                     probabilities[:, facies_idx],
-                    selected_zone_numbers_zero_indexed,
+                    zone_indices_for_selected_zone_numbers,
                     real_number,
                     is_shared=is_shared,
                 )

--- a/aps/algorithms/defineFaciesProbTrend.py
+++ b/aps/algorithms/defineFaciesProbTrend.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 import copy
 import numpy as np
-import xml.etree.ElementTree as ET
-from pathlib import Path
 from typing import List
 from aps.utils.roxar.generalFunctionsUsingRoxAPI import (
     set_continuous_3d_parameter_values,
@@ -14,10 +12,10 @@ from aps.utils.roxar.grid_model import (
 )
 from aps.algorithms.defineFacies import BaseDefineFacies
 from aps.utils.constants.simple import Debug
-from aps.utils.exceptions.xml import MissingKeyword
 from aps.utils.methods import get_cond_prob_dict
 from aps.utils.xmlUtils import getIntCommand
-from aps.utils.ymlUtils import get_text_value, get_bool_value, get_dict
+from aps.utils.ymlUtils import get_bool_value, get_dict
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 class DefineFaciesProb(BaseDefineFacies):
@@ -62,7 +60,7 @@ class DefineFaciesProb(BaseDefineFacies):
         # Check that parameters are specified
         if not self._use_const_prob:
             if len(self.probability_matrix) == 0:
-                raise ValueError(f'Missing specification of: CondProbMatrix')
+                raise ValueError('Missing specification of: CondProbMatrix')
 
     def _read_model_from_xml_root(self, debug_level: Debug = Debug.OFF):
         self._use_const_prob = (
@@ -144,6 +142,8 @@ class DefineFaciesProb(BaseDefineFacies):
         real_number = self.project.current_realisation
         grid_model = self.project.grid_models[self.grid_model_name]
         is_shared = grid_model.shared
+        grid = grid_model.get_grid(real_number)
+        zone_mapping = ZoneMapping(grid_model, grid, real_number=real_number)
 
         [zone_values, _] = getDiscrete3DParameterValues(
             grid_model, self.zone_param_name, real_number
@@ -240,14 +240,18 @@ class DefineFaciesProb(BaseDefineFacies):
                         f'Update parameter: {parameter_name} for zones '
                         f'{" ".join(str(zone_number) for zone_number in self.selected_zone_numbers)}:'
                     )
-                zone_number_list_zero_indexed = [
-                    znr - 1 for znr in self.selected_zone_numbers
-                ]
+                zone_index_list = []
+                for zone_number in self.selected_zone_numbers:
+                    zone_index = zone_mapping.get_zone_index_for_zone_number(
+                        zone_number
+                    )
+                    zone_index_list.append(zone_index)
+
                 success = set_continuous_3d_parameter_values(
                     grid_model,
                     parameter_name,
                     probability_values,
-                    zone_number_list_zero_indexed,
+                    zone_index_list,
                     real_number,
                     is_shared=is_shared,
                     debug_level=self.debug_level,
@@ -264,9 +268,11 @@ class DefineFaciesProb(BaseDefineFacies):
             # input (intepreted) facies realization is used as facies names for the probability cubes.
 
             # Create a new array with 0 probabilities for this facies
-            zone_number_list_zero_indexed = [
-                znr - 1 for znr in self.selected_zone_numbers
-            ]
+            zone_index_list = []
+            for zone_number in self.selected_zone_numbers:
+                zone_index = zone_mapping.get_zone_index_for_zone_number(zone_number)
+                zone_index_list.append(zone_index)
+
             probability_values = np.zeros(len(zone_values), np.float32)
 
             for code, facies_name in code_names_facies.items():
@@ -303,7 +309,7 @@ class DefineFaciesProb(BaseDefineFacies):
                     grid_model,
                     parameter_name,
                     probability_values,
-                    zone_number_list_zero_indexed,
+                    zone_index_list,
                     real_number,
                     is_shared=is_shared,
                     debug_level=self.debug_level,

--- a/aps/algorithms/trend/__init__.py
+++ b/aps/algorithms/trend/__init__.py
@@ -35,7 +35,6 @@ from aps.utils.constants.simple import (
     CrossSectionType,
     Direction,
     TrendParameter,
-    GridModelConstants,
 )
 
 from aps.utils.containers import FmuAttribute
@@ -53,6 +52,7 @@ from aps.utils.xmlUtils import (
     get_fmu_value_from_xml,
     get_origin_type_from_model_file,
 )
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 def required_parameters(_type: TrendType) -> List[TrendParameter]:
@@ -162,7 +162,7 @@ class Trend3D:
             trend_rule_xml, 'directionStacking', modelFile=model_file_name
         )
         if debug_level >= Debug.VERY_VERBOSE:
-            print(f'--- Trend parameters:')
+            print('--- Trend parameters:')
             print(f'---   Azimuth:        {azimuth}')
             print(f'---   Stacking angle: {stacking_angle}')
             print(f'---   Stacking type:  {stacking_direction}')
@@ -374,6 +374,7 @@ class Trend3D:
 
         # Using simbox indexer
         grid_3d = grid_model.get_grid(realization_number)
+        zone_mapping = ZoneMapping(grid_model, grid_3d, real_number=realization_number)
         grid_indexer = grid_3d.simbox_indexer
         (nx, ny, nz) = grid_indexer.dimensions
 
@@ -407,22 +408,16 @@ class Trend3D:
         else:
             cell_center_points = grid_3d.get_cell_centers(cell_index_defined)
 
-        zonation = grid_indexer.zonation
-        layer_ranges = zonation[zone_number - 1]
+        start_layer, end_layer = zone_mapping.get_start_end_layer_for_zone_number(
+            zone_number
+        )
         # In simbox there is only one interval of layers per zone and they
         # come after each other and layer numbering increases downwards
-        start_layer = np.infty
-        end_layer = -np.infty
-        for layer in layer_ranges:
-            if start_layer > layer[0]:
-                start_layer = layer[0]
-            if end_layer < layer[-1]:
-                end_layer = layer[-1]
 
         # Set start and end layer for this zone
         self._start_layer = start_layer
         self._end_layer = end_layer
-        num_layers_in_zone = sum(len(layer) for layer in layer_ranges)
+        num_layers_in_zone = zone_mapping.number_of_layers_for_zone_number(zone_number)
         zinc = sim_box_thickness / num_layers_in_zone
         if debug_level >= Debug.VERY_VERBOSE:
             print(f'---  In {self._class_name}')
@@ -533,7 +528,7 @@ class Trend3D:
             max_value = values_rescaled.max()
             minmax_difference = max_value - min_value
         else:
-            raise ValueError(f'Trend has no active cells')
+            raise ValueError('Trend has no active cells')
         return minmax_difference, values_rescaled
 
     def createTrendFor2DProjection(

--- a/aps/rms_jobs/APS_main.py
+++ b/aps/rms_jobs/APS_main.py
@@ -461,23 +461,21 @@ def run(
                 alpha_all = gf_all_alpha[gf_name]
                 if not use_CDF_transform:
                     if debug_level >= Debug.VERBOSE:
-                        print(f'-- Transformation type:  Empiric')
+                        print('-- Transformation type:  Empiric')
 
                     alpha_all = transform_empiric(
                         cell_index_defined, gauss_field_values_all, alpha_all
                     )
                 elif has_trend_in_gauss_field:
                     if debug_level >= Debug.VERBOSE:
-                        print(f'-- Transformation type:  Empiric since GRF has trend')
+                        print('-- Transformation type:  Empiric since GRF has trend')
 
                     alpha_all = transform_empiric(
                         cell_index_defined, gauss_field_values_all, alpha_all
                     )
                 else:
                     if debug_level >= Debug.VERBOSE:
-                        print(
-                            f'-- Transformation type:  Cumulative normal distribution'
-                        )
+                        print('-- Transformation type:  Cumulative normal distribution')
 
                     alpha_all = transform_CDF(
                         cell_index_defined, gauss_field_values_all, alpha_all
@@ -497,9 +495,6 @@ def run(
                         cell_index_defined,
                         realization_number,
                         variable_name_extension='transf',
-                        use_regions=use_regions,
-                        zone_number=zone_number,
-                        region_number=region_number,
                         debug_level=debug_level,
                     )
 

--- a/aps/rms_jobs/APS_simulate_gauss_singleprocessing.py
+++ b/aps/rms_jobs/APS_simulate_gauss_singleprocessing.py
@@ -9,15 +9,16 @@ import numpy as np
 from aps.algorithms.APSModel import APSModel
 from aps.utils.constants.simple import Debug
 from aps.utils.io import ensure_folder_exists
-from aps.utils.methods import get_specification_file, get_debug_level
+from aps.utils.methods import get_specification_file
 from aps.utils.roxar.generalFunctionsUsingRoxAPI import (
     set_continuous_3d_parameter_values_in_zone_region,
     get_project_realization_seed,
 )
-from aps.utils.roxar.grid_model import GridAttributes, get_zone_names
+from aps.utils.roxar.grid_model import GridAttributes
 from aps.utils.roxar.progress_bar import APSProgressBar
 from aps.utils.methods import get_seed_log_file
 from aps.utils.trend import add_trends
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 def define_variogram(variogram, azimuth_value_sim_box):
@@ -71,23 +72,32 @@ def run_simulations(
     # before calling the current script.
 
     grid_model = project.grid_models[aps_model.grid_model_name]
-    zone_names = get_zone_names(grid_model)
+    grid = grid_model.get_grid(realisation)
+
+    zone_mapping = ZoneMapping(
+        grid_model,
+        grid,
+        real_number=project.current_realisation,
+        fmu_mode=fmu_mode,
+        debug_level=debug_level.value,
+    )
+    if debug_level >= Debug.VERY_VERBOSE:
+        print(
+            f'--- ZoneMapping zones in grid:  {zone_mapping.get_zone_names_from_grid()}'
+        )
+        print(
+            f'--- ZoneMapping zones in param:  {zone_mapping.get_zone_names_from_param()}'
+        )
+    grid_attributes = GridAttributes(grid, zone_mapping, debug_level=debug_level)
+    number_of_zones = zone_mapping.get_number_of_zones_in_grid()
     if fmu_mode:
         # Ensure that the grid is shared and the realisation number
         # is 1 and that there are only one zone and one region.
         if realisation > 1:
             raise ValueError('The realisation number must be 1 in FMU mode.')
-        grid = grid_model.get_grid(realisation)
-        # Get grid dimensions
-        grid_attributes = GridAttributes(grid, zone_names, debug_level=Debug.OFF)
-        num_layers_per_zone = grid_attributes.num_layers_per_zone
-        if len(num_layers_per_zone) != 1:
+
+        if number_of_zones != 1:
             raise ValueError('The ERTBOX grid can only have 1 zone')
-    else:
-        grid = grid_model.get_grid(realisation)
-        # Get grid dimensions
-        grid_attributes = GridAttributes(grid, zone_names, debug_level=debug_level)
-        num_layers_per_zone = grid_attributes.num_layers_per_zone
 
     nx, ny, nz = grid_attributes.simbox_dimensions
 
@@ -108,14 +118,21 @@ def run_simulations(
         if not aps_model.isSelected(zone_number, region_number):
             continue
         gauss_field_names = zone_model.gaussian_fields_in_truncation_rule
-        # Add zone names / number, if FMU
+
+        # The zone number must be converted to zone index, but zone_number is used to report
+        # to log file. This is because we want to handle two cases, normal
+        # case with geogrid and special case with ERTBOX grid
+        zone_index = None
         if fmu_mode:
-            assert len(num_layers_per_zone) == 1
+            # Only one zone is expected in ERTBOX grid
             zone_index = 0
+            assert zone_mapping.get_number_of_zones_in_grid() == 1
+
+            num_layers = zone_mapping.number_of_layers_for_zone_index(zone_index)
         else:
-            # Zone index is counted from 0 while zone number from 1
-            zone_index = zone_number - 1
-        num_layers = num_layers_per_zone[zone_index]
+            # For geomodel grid handle zones normally
+            zone_index = zone_mapping.get_zone_index_for_zone_number(zone_number)
+            num_layers = zone_mapping.number_of_layers_for_zone_number(zone_number)
 
         # Calculate grid cell size in z direction
         nz = num_layers
@@ -127,10 +144,9 @@ def run_simulations(
             else:
                 print(f'- Zone: {zone_number}   Region: {region_number}  ')
         if debug_level >= Debug.VERY_VERBOSE:
-            start = grid_attributes.start_layers_per_zone[zone_index]
-            end = grid_attributes.end_layers_per_zone[zone_index]
+            start, end = zone_mapping.get_start_end_layer_for_zone_index(zone_index)
             print(
-                f'--- Grid layers: {num_layers} Start layer: {start + 1} End layer: {end}'
+                f'--- Grid layers: {num_layers} Start layer: {start + 1} End layer: {end + 1}'
             )
 
         gauss_result_list_for_zone = []
@@ -230,7 +246,7 @@ def run_simulations(
             grid_model,
             gauss_field_names,
             gauss_result_list_for_zone,
-            zone_number,
+            zone_index,
             region_number=region_number,
             region_parameter_name=aps_model.region_parameter,
             realisation_number=realisation,

--- a/aps/rms_jobs/copy_rms_param_trend_to_fmu_grid.py
+++ b/aps/rms_jobs/copy_rms_param_trend_to_fmu_grid.py
@@ -12,12 +12,10 @@ from aps.utils.constants.simple import (
     TrendType,
 )
 from aps.utils.roxar.grid_model import (
-    get_zone_layer_numbering,
-    get_zone_names,
     get_grid_model,
 )
 from aps.utils.roxar.progress_bar import APSProgressBar
-
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 # The functionality to copy between geogrid and ertbox grid is now placed
 # in fmu.tools.rms function copy_rms_param
@@ -41,8 +39,10 @@ def get_trend_param_names_from_aps_model(
     geo_grid_model_name = aps_model.grid_model_name
     geogrid_model, geogrid = get_grid_model(project, geo_grid_model_name)
     _, ertboxgrid = get_grid_model(project, ertbox_grid_model_name)
-    zone_names = get_zone_names(geogrid_model)
-    number_layers_per_zone, _, _ = get_zone_layer_numbering(geogrid)
+
+    zone_mapping = ZoneMapping(
+        geogrid_model, geogrid, real_number=project.current_realisation
+    )
     nz_ertbox = ertboxgrid.simbox_indexer.dimensions[2]
     real_number = project.current_realisation
 
@@ -51,11 +51,12 @@ def get_trend_param_names_from_aps_model(
     use_rms_param_trend = False
     all_zone_models = aps_model.sorted_zone_models
     for key, zone_model in all_zone_models.items():
-        zone_number, region_number = key
+        (zone_number, region_number) = key
         if not aps_model.isSelected(zone_number, region_number):
             continue
-        zone_index = zone_number - 1
-        zone_name = zone_names[zone_index]
+
+        zone_name = zone_mapping.get_zone_name_for_zone_number(zone_number)
+        number_layers = zone_mapping.number_of_layers_for_zone_number(zone_number)
 
         # Only check that zone_model.grid_layout is
         # consistent with the grid.
@@ -66,14 +67,12 @@ def get_trend_param_names_from_aps_model(
         job_name = rmsapi.rms.get_running_job_name()
         check_grid_layout(
             geo_grid_model_name,
-            zone_number,
+            zone_name,
             zone_model.grid_layout.value,
             aps_job_name=job_name,
             return_grid_layout=False,
             debug_level=debug_level,
         )
-
-        number_layers = number_layers_per_zone[zone_number - 1]
 
         if number_layers > nz_ertbox:
             raise ValueError(
@@ -160,6 +159,13 @@ def run(
         project, aps_model, ertbox_grid_model_name, debug_level=debug_level
     )
 
+    # Get zone mapping
+    geogrid_model = project.grid_models[geo_grid_model_name]
+    geogrid = geogrid_model.get_grid(project.current_realisation)
+    zone_mapping = ZoneMapping(
+        geogrid_model, geogrid, real_number=project.current_realisation
+    )
+
     # Independent of using custom trends or not we can save active parameter in ertbox
     # corresponding to the geomodel zone.
     if save_active_param_to_ertbox:
@@ -168,6 +174,7 @@ def run(
             geo_grid_model_name,
             ertbox_grid_model_name,
             zone_dict,
+            zone_mapping,
             debug_level=int(debug_level),
         )
 

--- a/aps/rms_jobs/create_zone_parameter.py
+++ b/aps/rms_jobs/create_zone_parameter.py
@@ -1,16 +1,10 @@
 from aps.algorithms.APSModel import APSModel
 from aps.utils.constants.simple import GridModelConstants, Debug
-from aps.utils.roxar.grid_model import create_zone_parameter, get_zone_names
+from aps.utils.roxar.grid_model import (
+    create_zone_parameter,
+)
 from roxar import GridPropertyType
-
-
-def get_zone_number_from_grid(grid_model, realization_number):
-    zonations = grid_model.get_grid(realization_number).simbox_indexer.zonation
-    return [key + 1 for key in zonations.keys()]
-
-
-def get_zone_names_from_grid(grid_model, realization_number):
-    return grid_model.get_grid(realization_number).zone_names
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 def get_codes_from_zone_param(grid_model, realization_number):
@@ -32,6 +26,8 @@ def run(project, aps_model: APSModel, debug_level, **kwargs):
     grid_model = project.grid_models[aps_model.grid_model_name]
     set_shared = grid_model.shared
     realization_number = project.current_realisation
+    grid = grid_model.get_grid(realization_number)
+    zone_mapping = ZoneMapping(grid_model, grid, real_number=realization_number)
     zone_parameter_name = GridModelConstants.ZONE_NAME
     if debug_level >= Debug.VERBOSE:
         print(f'-- Checking to see whether {zone_parameter_name} must be created')
@@ -40,20 +36,10 @@ def run(project, aps_model: APSModel, debug_level, **kwargs):
         codes = get_codes_from_zone_param(grid_model, realization_number)
         if len(codes) > 0:
             # The zone parameter exist for this realization
-            zone_numbers_from_grid = get_zone_number_from_grid(
-                grid_model, realization_number
-            )
-            zone_names_from_grid = get_zone_names_from_grid(
-                grid_model, realization_number
-            )
-            zone_names_from_param = get_zone_names(grid_model)
-            if set(zone_numbers_from_grid) != set(codes):
-                raise ValueError(
-                    f'There is a mismatch between the zone numbers as defined in {zone_parameter_name} '
-                    f'({codes}), and in the zones for the grid: {zone_numbers_from_grid}).\n'
-                    f'A solution to this, is to delete the {zone_parameter_name} property '
-                    f'from {aps_model.grid_model_name}.'
-                )
+            zone_names_from_grid = zone_mapping.get_zone_names_from_grid()
+            zone_names_from_param_dict = zone_mapping.get_zone_names_from_param()
+            zone_names_from_param = list(zone_names_from_param_dict.values())
+
             if zone_names_from_grid != zone_names_from_param:
                 print(
                     f'NOTE:\n'

--- a/aps/rms_jobs/import_fields_from_disk.py
+++ b/aps/rms_jobs/import_fields_from_disk.py
@@ -37,8 +37,6 @@ import xtgeo
 from aps.algorithms.APSModel import APSModel
 from aps.utils.constants.simple import Debug
 from aps.utils.roxar.grid_model import (
-    create_zone_parameter,
-    get_zone_layer_numbering,
     getContinuous3DParameterValues,
     GridSimBoxSize,
     flip_grid_index_origo,
@@ -53,6 +51,7 @@ from aps.utils.aps_config import APSConfig
 from fmu.tools.rms.copy_rms_param_to_ertbox_grid import (
     extract_values_from_ertbox_grid_to_geogrid_simbox,
 )
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 def get_field_name(field_name, zone):
@@ -170,7 +169,9 @@ def run(project, model_file, geo_grid_name, load_dir=None, **kwargs):
             f'is empty for realization {project.current_realisation}.'
         )
     grid3D = geo_grid_model.get_grid(project.current_realisation)
-    number_of_layers_per_zone_in_geo_grid, _, _ = get_zone_layer_numbering(grid3D)
+    zone_mapping = ZoneMapping(
+        geo_grid_model, grid3D, real_number=project.current_realisation
+    )
     attributes = GridSimBoxSize(grid3D, debug_level=debug_level)
     handedness = attributes.handedness
 
@@ -186,14 +187,6 @@ def run(project, model_file, geo_grid_name, load_dir=None, **kwargs):
     if file_format.upper() == 'GRDECL':
         xtgeo_fmu_grid = xtgeo.grid_from_roxar(project, fmu_grid_name)
 
-    # Get zone parameter for geomodel grid if it exist.
-    # Create it if non-existing. Fill it if empty.
-    zone_property = create_zone_parameter(
-        geo_grid_model,
-        realization_number=project.current_realisation,
-        set_shared=geo_grid_model.shared,
-    )
-    zone_names = zone_property.code_names
     region_names = None
     region_param_name = None
     if aps_model.use_regions:
@@ -209,11 +202,10 @@ def run(project, model_file, geo_grid_name, load_dir=None, **kwargs):
             aps_model,
             fmu_grid_model,
             geo_grid_model,
-            zone_names,
+            zone_mapping,
             load_dir,
             file_format,
             xtgeo_fmu_grid,
-            number_of_layers_per_zone_in_geo_grid,
             region_names=region_names,
             region_param_name=region_param_name,
             debug_level=debug_level,
@@ -224,11 +216,10 @@ def run(project, model_file, geo_grid_name, load_dir=None, **kwargs):
             aps_model,
             fmu_grid_model,
             geo_grid_model,
-            zone_names,
+            zone_mapping,
             load_dir,
             file_format,
             xtgeo_fmu_grid,
-            number_of_layers_per_zone_in_geo_grid,
             handedness=handedness,
             region_names=region_names,
             region_param_name=region_param_name,
@@ -243,11 +234,10 @@ def import_and_update_ertbox_and_geogrid(
     aps_model: APSModel,
     fmu_grid_model,
     geo_grid_model,
-    zone_names: dict,
+    zone_mapping: ZoneMapping,
     load_dir: Path,
     file_format: str,
     xtgeo_fmu_grid: xtgeo.Grid,
-    number_of_layers_per_zone_in_geo_grid: list,
     region_names: dict = None,
     region_param_name: str = None,
     debug_level: Debug = Debug.OFF,
@@ -255,7 +245,7 @@ def import_and_update_ertbox_and_geogrid(
     # Loop over all zones defined in aps model
     for zone in aps_model.zone_models:
         if aps_model.isSelected(zone.zone_number, zone.region_number):
-            zone_name = zone_names[zone.zone_number]
+            zone_name = zone_mapping.get_zone_name_for_zone_number(zone.zone_number)
             region_name = ''
             if region_names:
                 region_name = region_names[zone.region_number]
@@ -267,7 +257,7 @@ def import_and_update_ertbox_and_geogrid(
             parameter_values_geo_grid = []
 
             # Get the sub set of values from fmu grid that should be mapped into geogrid for the current zone
-            nz_layers = number_of_layers_per_zone_in_geo_grid[zone.zone_number - 1]
+            nz_layers = zone_mapping.number_of_layers_for_zone_number(zone.zone_number)
             for full_field_name in zone.gaussian_fields_in_truncation_rule:
                 field_name = field_name_from_full_name(
                     full_field_name, zone_name, region_name=region_name
@@ -325,12 +315,12 @@ def import_and_update_ertbox_and_geogrid(
                     print(
                         f'--- Load parameter {name} from file into {fmu_grid_model.name}'
                     )
-            zone_number_fmu_grid = 1
+            zone_index_fmu_grid = 0
             set_continuous_3d_parameter_values_in_zone_region(
                 fmu_grid_model,
                 parameter_names_fmu_grid,
                 parameter_values_fmu_grid,
-                zone_number_fmu_grid,
+                zone_index_fmu_grid,
                 realisation_number=project.current_realisation,
                 is_shared=fmu_grid_model.shared,
             )
@@ -346,12 +336,12 @@ def import_and_update_ertbox_and_geogrid(
                         print(
                             f'--- Update parameter {name} for zone number {zone.zone_number} in {geo_grid_model.name}'
                         )
-
+            zone_index = zone_mapping.get_zone_index_for_zone_number(zone.zone_number)
             set_continuous_3d_parameter_values_in_zone_region(
                 geo_grid_model,
                 parameter_names_geo_grid,
                 parameter_values_geo_grid,
-                zone.zone_number,
+                zone_index,
                 zone.region_number,
                 region_parameter_name=region_param_name,
                 realisation_number=project.current_realisation,
@@ -364,11 +354,10 @@ def import_and_update_ertbox_and_geogrid_with_residuals(
     aps_model: APSModel,
     fmu_grid_model,
     geo_grid_model,
-    zone_names: dict,
+    zone_mapping: ZoneMapping,
     load_dir: Path,
     file_format: str,
     xtgeo_fmu_grid: xtgeo.Grid,
-    number_of_layers_per_zone_in_geo_grid: list,
     handedness=Direction.right,
     region_names: dict = None,
     region_param_name: str = None,
@@ -382,7 +371,7 @@ def import_and_update_ertbox_and_geogrid_with_residuals(
 
     for zone in aps_model.zone_models:
         if aps_model.isSelected(zone.zone_number, 0):
-            zone_name = zone_names[zone.zone_number]
+            zone_name = zone_mapping.get_zone_name_for_zone_number(zone.zone_number)
             region_name = ''
             if aps_model.use_regions:
                 region_name = region_names[zone.region_number]
@@ -393,8 +382,7 @@ def import_and_update_ertbox_and_geogrid_with_residuals(
             parameter_values_geo_grid = []
 
             # Get the sub set of values from fmu grid that should be mapped into geogrid for the current zone
-            nz_layers = number_of_layers_per_zone_in_geo_grid[zone.zone_number - 1]
-
+            nz_layers = zone_mapping.number_of_layers_for_zone_number(zone.zone_number)
             for full_field_name in zone.gaussian_fields_in_truncation_rule:
                 field_name = field_name_from_full_name(
                     full_field_name, zone_name, region_name=region_name
@@ -438,12 +426,12 @@ def import_and_update_ertbox_and_geogrid_with_residuals(
                     print(
                         f'--- Load parameter {name} from file into {fmu_grid_model.name}'
                     )
-            zone_number_fmu_grid = 1
+            zone_index_fmu_grid = 0
             set_continuous_3d_parameter_values_in_zone_region(
                 fmu_grid_model,
                 parameter_names_fmu_grid,
                 parameter_values_fmu_grid,
-                zone_number_fmu_grid,
+                zone_index_fmu_grid,
                 realisation_number=project.current_realisation,
                 is_shared=fmu_grid_model.shared,
             )
@@ -494,12 +482,12 @@ def import_and_update_ertbox_and_geogrid_with_residuals(
                         print(
                             f'-- Update parameter {name} for zone number {zone.zone_number} in {geo_grid_model.name}'
                         )
-
+            zone_index = zone_mapping.get_zone_index_for_zone_number(zone.zone_number)
             set_continuous_3d_parameter_values_in_zone_region(
                 geo_grid_model,
                 parameter_names_geo_grid,
                 parameter_values_geo_grid,
-                zone.zone_number,
+                zone_index,
                 zone.region_number,
                 region_parameter_name=region_param_name,
                 realisation_number=project.current_realisation,

--- a/aps/rms_jobs/test_create_simulation_grid.py
+++ b/aps/rms_jobs/test_create_simulation_grid.py
@@ -1,6 +1,6 @@
 #!/bin/python
 from aps.rms_jobs.create_simulation_grid import run as run_create_grid
-from aps.utils.roxar.grid_model import GridSimBoxSize
+
 from aps.algorithms.APSModel import APSModel
 from aps.utils.constants.simple import Debug
 

--- a/aps/toolbox/check_and_normalise_probability.py
+++ b/aps/toolbox/check_and_normalise_probability.py
@@ -167,10 +167,9 @@ from aps.utils.roxar.grid_model import (
     getContinuous3DParameterValues,
     getDiscrete3DParameterValues,
     find_defined_cells,
-    create_zone_parameter,
 )
 from aps.utils.checks import check_probability_values, check_probability_normalisation
-from aps.utils.methods import check_missing_keywords_list, check_missing_keywords_dict
+from aps.utils.methods import check_missing_keywords_list
 
 
 class NormalisationError(ValueError):
@@ -183,7 +182,7 @@ def run(params):
     """
     project = params.get('project', None)
     if project is None:
-        raise ValueError(f"Missing specification of the project variable in 'params' ")
+        raise ValueError("Missing specification of the project variable in 'params' ")
 
     real_number = project.current_realisation
     print(
@@ -334,13 +333,13 @@ def check_and_normalize_probabilities_for_APS(
 
         if not overwrite:
             parameter_name = parameter_name + '_norm'
-        zone_number_list = []
+        zone_index_list = []
         is_shared = grid_model.shared
         update_successful = set_continuous_3d_parameter_values(
             grid_model,
             parameter_name,
             parameter_values,
-            zone_number_list,
+            zone_index_list,
             realization_number,
             is_shared=is_shared,
         )

--- a/aps/toolbox/copy_rms_param_to_ertbox_grid.py
+++ b/aps/toolbox/copy_rms_param_to_ertbox_grid.py
@@ -22,11 +22,10 @@ from aps.rms_jobs.copy_rms_param_trend_to_fmu_grid import (
 
 from aps.utils.ymlUtils import get_text_value, get_dict, get_bool_value, readYml
 from aps.utils.methods import check_missing_keywords_list
-from aps.utils.roxar.grid_model import get_zone_layer_numbering
 from aps.utils.roxar.generalFunctionsUsingRoxAPI import (
     set_continuous_3d_parameter_values_in_zone_region,
 )
-
+from fmu.tools.rms.zone_mapping import ZoneMapping
 # TODO: When the stubs are removed, this function is no longe necessary since
 # this functionality is implemented in fmu.tools.rms.copy_rms_param
 
@@ -307,6 +306,7 @@ def from_ertbox_to_geogrid(project, params):
 
     # Create
     geogrid_model, grid3D = get_grid_model(project, grid_model_name)
+    zone_mapping = ZoneMapping(geogrid_model, grid3D, real_number=real_number)
     ertbox_grid_model, ertbox3D = get_grid_model(project, ertbox_grid_model_name)
 
     # Check grid index origin
@@ -324,10 +324,8 @@ def from_ertbox_to_geogrid(project, params):
         print("WARNING: ERTBOX grid should have 'Eclipse grid index origin'.")
         print('         Use the grid index origin job in RMS to set this.')
 
-    number_of_layers_per_zone_in_geo_grid, _, _ = get_zone_layer_numbering(grid3D)
     nx, ny, nz_ertbox = ertbox3D.simbox_indexer.dimensions
     for zone_number in param_names_geogrid_dict:
-        zone_index = zone_number - 1
         conformity = conformity_dict[zone_number]
         param_names_geogrid_list = param_names_geogrid_dict[zone_number]
         param_names_ertbox_list = param_names_ertbox_dict[zone_number]
@@ -336,7 +334,7 @@ def from_ertbox_to_geogrid(project, params):
             print(f'-- Conformity: {conformity}  ')
             print(f'-- Copy from:  {param_names_ertbox_list}')
             print(f'-- Copy to:    {param_names_geogrid_list}')
-        nz_for_zone = number_of_layers_per_zone_in_geo_grid[zone_index]
+        nz_for_zone = zone_mapping.number_of_layers_for_zone_number(zone_number)
         parameter_names_geo_grid = []
         parameter_values_geo_grid = []
 
@@ -369,12 +367,12 @@ def from_ertbox_to_geogrid(project, params):
                 print(
                     f'--- Update parameter {name} for zone number {zone_number} in {geogrid_model}'
                 )
-
+        zone_index = zone_mapping.get_zone_index_for_zone_number(zone_number)
         set_continuous_3d_parameter_values_in_zone_region(
             geogrid_model,
             parameter_names_geo_grid,
             parameter_values_geo_grid,
-            zone_number,
+            zone_index,
             realisation_number=project.current_realisation,
             is_shared=geogrid_model.shared,
             switch_handedness=True,

--- a/aps/utils/fmu.py
+++ b/aps/utils/fmu.py
@@ -4,7 +4,6 @@ import os
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from collections import defaultdict
-from warnings import warn
 from typing import (
     Dict,
     Tuple,
@@ -18,8 +17,6 @@ from typing import (
 from pathlib import Path
 
 import numpy as np
-import xtgeo
-from xtgeo.grid3d import GridProperty
 
 from roxar import Project
 from roxar.grids import Grid3D, GridModel
@@ -31,41 +28,13 @@ from aps.utils.constants.simple import OriginType, Debug, TrendType, GridModelCo
 from aps.utils.decorators import cached
 from aps.utils.exceptions.zone import MissingConformityException
 from aps.utils.aps_config import APSConfig
-
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 if TYPE_CHECKING:
     from typing import Literal
 
     # Literal was introduced in Python 3.8
     Handedness = Literal['left', 'right']
-
-
-def create_get_property(
-    project: Project,
-    aps_model: Optional[Union[APSModel, str]],
-) -> Callable[[str, Optional[str]], GridProperty]:
-    def get_property(name, grid_name=None):
-        if grid_name is None:
-            if aps_model is None:
-                raise ValueError(
-                    "'aps_model' must be given, if 'grid_name' is not given"
-                )
-            grid_name = _get_grid_name(aps_model)
-        properties = project.grid_models[grid_name].properties
-        if name in properties:
-            if properties[name].is_empty(project.current_realisation):
-                raise ValueError(
-                    f'The parameter {name} is empty in grid model {grid_name}'
-                )
-        else:
-            raise ValueError(
-                f'The parameter  {name} does not exist in grid model {grid_name}'
-            )
-        return xtgeo.gridproperty_from_roxar(
-            project, grid_name, name, project.current_realisation
-        )
-
-    return get_property
 
 
 def get_top_location() -> Path:
@@ -112,7 +81,7 @@ def is_initial_iteration_check_file(debug_level: Debug = Debug.OFF) -> bool:
             iterfolder = folder
             break
     if iterfolder == -1:
-        print(f'Warning: When running ERT version < 5.0 specify a forward model')
+        print('Warning: When running ERT version < 5.0 specify a forward model')
         print('         creating a directory with name equal to iteration number.')
         print('         If folder does not exists, APS will assume iteration = 0.')
 
@@ -135,6 +104,13 @@ def get_grid(
     return project.grid_models[_get_grid_name(aps_model)].get_grid(
         project.current_realisation
     )
+
+
+def get_zone_mapping(project: Project, aps_model: Union[APSModel, str]) -> ZoneMapping:
+    grid_model = project.grid_models[_get_grid_name(aps_model)]
+    grid = grid_model.get_grid(project.current_realisation)
+    zone_mapping = ZoneMapping(grid_model, grid, project.current_realisation)
+    return zone_mapping
 
 
 def _get_grid_name(arg: Union[str, APSModel]) -> str:
@@ -183,15 +159,7 @@ class SimBoxDependentUpdate(UpdateModel, metaclass=ABCMeta):
         super().__init__(**kwargs)
         self.project = project
         self.ert_grid_name = fmu_simulation_grid_name
-
-    @property
-    @cached
-    def layers_in_geo_model_zones(self) -> List[int]:
-        grid = get_grid(self.project, self.aps_model)
-        layers = []
-        for zonation, *reverse in grid.grid_indexer.zonation.values():
-            layers.append(zonation.stop - zonation.start)
-        return layers
+        self.zone_mapping = get_zone_mapping(self.project, self.aps_model)
 
     @property
     @cached
@@ -437,7 +405,9 @@ class UpdateSimBoxThicknessInZones(SimBoxDependentUpdate):
 
     def before(self):
         for zone_model in self.zone_models:
-            nz_geo_grid = self.layers_in_geo_model_zones[zone_model.zone_number - 1]
+            nz_geo_grid = self.zone_mapping.number_of_layers_for_zone_number(
+                zone_model.zone_number
+            )
             zone_model.sim_box_thickness = (
                 zone_model.sim_box_thickness * self.nz_fmu_box / nz_geo_grid
             )
@@ -452,7 +422,9 @@ class UpdateRelativeSizeForEllipticConeTrend(TrendUpdate):
         self, zone_model: APSZoneModel, field_model: GaussianField
     ) -> None:
         nz_fmu_box = self.nz_fmu_box
-        nz_geo_grid = self.layers_in_geo_model_zones[zone_model.zone_number - 1]
+        nz_geo_grid = self.zone_mapping.number_of_layers_for_zone_number(
+            zone_model.zone_number
+        )
         original_relative_size = self.get_original_value(zone_model, field_model)
         if zone_model.grid_layout in [Conform.Proportional, Conform.TopConform]:
             fmu_relative_size = original_relative_size / (
@@ -503,11 +475,9 @@ class UpdateRelativePositionOfTrends(TrendUpdate):
         self, zone_model: APSZoneModel, field_model: GaussianField
     ) -> None:
         nz_fmu = self.nz_fmu_box
-        indexer = get_grid(self.project, self.aps_model.grid_model_name).simbox_indexer
-
-        zonation, *_reverse = indexer.zonation[zone_model.zone_number - 1]
-        nz_zone = zonation.stop - zonation.start
-
+        nz_zone = self.zone_mapping.number_of_layers_for_zone_number(
+            zone_model.zone_number
+        )
         trend = field_model.trend.model
         if self.has_appropriate_trend(field_model):
             z_original = float(trend.origin.z)

--- a/aps/utils/grid.py
+++ b/aps/utils/grid.py
@@ -11,9 +11,6 @@ def update_rms_parameter(
     cell_index_defined,
     realization_number,
     variable_name_extension=None,
-    use_regions=False,
-    zone_number=0,
-    region_number=0,
     debug_level=Debug.OFF,
     is_shared=False,
 ):

--- a/aps/utils/roxar/generalFunctionsUsingRoxAPI.py
+++ b/aps/utils/roxar/generalFunctionsUsingRoxAPI.py
@@ -7,14 +7,13 @@ import numpy as np
 from warnings import warn
 
 from aps.utils.exceptions.general import raise_error
-from aps.utils.io import print_debug_information, print_error
 from aps.utils.roxar.grid_model import (
     get3DParameter,
     modify_selected_grid_cells,
     update_code_names,
 )
 from aps.utils.constants.simple import Debug
-
+from fmu.tools.rms.zone_mapping import ZoneMapping
 import roxar
 from roxar import Direction
 
@@ -45,7 +44,7 @@ def set_continuous_3d_parameter_values(
     grid_model,
     parameter_name,
     input_values,
-    zone_numbers=None,
+    zone_indices=None,
     realisation_number=0,
     is_shared=False,
     debug_level=Debug.OFF,
@@ -57,7 +56,7 @@ def set_continuous_3d_parameter_values(
            input_values    - A numpy array of length equal to the number of active cells and with continuous values.
                            Only the grid cells belonging to the specified zones are updated even though the values array
                            contain values for all active cells.
-           zone_numbers - A list of integer values that are zone numbers (counted from 0).
+           zone_indices    - A list of integer values that are zone indices (counted from 0).
                             If the list is empty or has all zones included in the list,
                             then grid cells in all zones are updated.
            realisation_number    - Realisation number counted from 0 for the parameter to get.
@@ -91,7 +90,7 @@ def set_continuous_3d_parameter_values(
             grid_model,
             input_values,
             parameter_name,
-            zone_numbers,
+            zone_indices,
             is_shared,
             realisation_number,
         )
@@ -117,7 +116,7 @@ def set_continuous_3d_parameter_values(
 
         current_values = p.get_values(realisation_number)
         current_values = modify_selected_grid_cells(
-            grid_model, zone_numbers, realisation_number, current_values, input_values
+            grid_model, zone_indices, realisation_number, current_values, input_values
         )
         p.set_values(current_values, realisation_number)
 
@@ -128,7 +127,7 @@ def set_continuous_3d_parameter_values_in_zone(
     grid_model,
     parameter_names,
     input_values_for_zones,
-    zone_number,
+    zone_index,
     realisation_number=0,
     is_shared=False,
     debug_level=Debug.OFF,
@@ -146,7 +145,7 @@ def set_continuous_3d_parameter_values_in_zone(
                                      numpy.float32. Only the grid cells belonging to the specified zone are updated,
                                      and error is raised if the number of grid cells for the zone doesn't match
                                      the size of the input array.
-           zoneNumber    - The zone number (counted from 0 in the input)
+           zone_index             - The zone index (counted from 0 in the input). Zone index refer to zone in grid.
            realisation_number    - Realisation number counted from 0 for the parameter to get.
            is_shared      - Is set to true or false if the parameter is to be set to shared or non-shared.
            debug_level   - (value 0,1,2 or 3) and specify how much info is to be printed to screen.
@@ -162,20 +161,12 @@ def set_continuous_3d_parameter_values_in_zone(
 
     # Check if the parameter is defined and create new if not existing
     grid = grid_model.get_grid(realisation_number)
+    zone_mapping = ZoneMapping(grid_model, grid, real_number=realisation_number)
 
     # Find grid layers for the zone
     indexer = grid.simbox_indexer
-    zonation = indexer.zonation
-    layer_ranges = zonation[zone_number]
     nx, ny, nz = indexer.dimensions
-    start_layer = nz
-    end_layer = 0
-    for layer_range in layer_ranges:
-        for layer in layer_range:
-            if start_layer > layer:
-                start_layer = layer
-            if end_layer < layer:
-                end_layer = layer
+    start_layer, end_layer = zone_mapping.get_start_end_layer_for_zone_index(zone_index)
     end_layer = end_layer + 1
     start = (0, 0, start_layer)
     end = (nx, ny, end_layer)
@@ -189,7 +180,7 @@ def set_continuous_3d_parameter_values_in_zone(
             'Input array with values has different dimensions than the grid model:\n'
             f'Grid model nx: {nx}  Input array nx: {nx_in}\n'
             f'Grid model ny: {ny}  Input array ny: {ny_in}\n'
-            f'Grid model nLayers for zone {zone_number} is: {num_layers}    Input array nz: {nz_in}'
+            f'Grid model nLayers for zone with index {zone_index} is: {num_layers}    Input array nz: {nz_in}'
         )
 
     defined_cell_indices = indexer.get_indices(zone_cell_numbers)
@@ -279,7 +270,7 @@ def set_continuous_3d_parameter_values_in_zone_region(
     grid_model,
     parameter_names,
     input_values_for_zones,
-    zone_number,
+    zone_index,
     region_number=0,
     region_parameter_name=None,
     realisation_number=0,
@@ -303,7 +294,7 @@ def set_continuous_3d_parameter_values_in_zone_region(
                                      numpy.float32. Only the grid cells belonging to the specified zone are updated,
                                      and error is raised if the number of grid cells for the zone doesn't match
                                      the size of the input array.
-           zone_number    - The zone number (counted from 1 in the input)
+           zone_index    - The zone index is referring to zone in grid
            regionNumber  - The region number for the grid cells to be updated.
            region_parameter_name - The name of the 3D grid parameter containing a discrete 3D parameter with region numbers
            realisation_number    - Realisation number counted from 0 for the parameter to get.
@@ -312,7 +303,6 @@ def set_continuous_3d_parameter_values_in_zone_region(
                            (0 - almost nothing, 3 - also some debug info)
     """
 
-    function_name = set_continuous_3d_parameter_values_in_zone_region.__name__
     # Check if specified grid model exists and is not empty
     if grid_model.is_empty(realisation_number):
         print(
@@ -322,6 +312,9 @@ def set_continuous_3d_parameter_values_in_zone_region(
 
     # Check if the parameter is defined and create new if not existing
     grid = grid_model.get_grid(realisation_number)
+    zone_mapping = ZoneMapping(
+        grid_model, grid, real_number=realisation_number, fmu_mode=fmu_mode
+    )
 
     # Find grid layers for the zone
     indexer = grid.simbox_indexer
@@ -331,7 +324,14 @@ def set_continuous_3d_parameter_values_in_zone_region(
         ijk_handedness = indexer.handedness
 
     nx, ny, nz = indexer.dimensions
-    end_layer, start_layer = get_layer_range(indexer, zone_number, fmu_mode)
+    if fmu_mode and len(indexer.zonation) != 1:
+        raise ValueError(
+            'While in FMU / ERT mode, the ERTBOX grid must have EXACTLY 1 zone'
+        )
+
+    start_layer, end_layer = zone_mapping.get_start_end_layer_for_zone_index(zone_index)
+    end_layer = end_layer + 1
+    zone_name = zone_mapping.get_zone_name_for_zone_index(zone_index)
     start = (0, 0, start_layer)
     end = (nx, ny, end_layer)
     zone_cell_numbers = indexer.get_cell_numbers_in_range(start, end)
@@ -344,7 +344,7 @@ def set_continuous_3d_parameter_values_in_zone_region(
             'Input array with values has different dimensions than the grid model:\n'
             f'Grid model nx: {nx}  Input array nx: {nx_in}\n'
             f'Grid model ny: {ny}  Input array ny: {ny_in}\n'
-            f'Grid model nLayers for zone {zone_number} is: {num_layers}    Input array nz: {nz_in}'
+            f'Grid model nLayers for zone index {zone_index} is: {num_layers}    Input array nz: {nz_in}'
         )
     use_regions = False
     if region_parameter_name is None or len(region_parameter_name) == 0 or fmu_mode:
@@ -436,31 +436,9 @@ def set_continuous_3d_parameter_values_in_zone_region(
             ]
 
         property_param.set_values(current_values, realisation_number)
-
+        if debug_level >= Debug.VERY_VERBOSE:
+            print(f'--- Updated zone: {zone_name} for parameter: {parameter_name}')
     return True
-
-
-def get_layer_range(indexer, zone_number, fmu_mode=False):
-    _, _, nz = indexer.dimensions
-    if fmu_mode:
-        if len(indexer.zonation) == 1:
-            layer_ranges = indexer.zonation[0]
-        else:
-            raise ValueError(
-                'While in FMU / ERT mode, the grid must have EXACTLY 1 zone'
-            )
-    else:
-        layer_ranges = indexer.zonation[
-            zone_number - 1
-        ]  # Zonation is 0-indexed, while zone numbers are 1-indexed
-    start_layer = nz
-    end_layer = 0
-    for layer_range in layer_ranges:
-        if start_layer > layer_range.start:
-            start_layer = layer_range.start
-        if end_layer < layer_range.stop:
-            end_layer = layer_range.stop
-    return end_layer, start_layer
 
 
 def update_continuous_3d_parameter_values(
@@ -503,7 +481,6 @@ def update_continuous_3d_parameter_values(
     if input_values is None:
         return
 
-    function_name = update_continuous_3d_parameter_values.__name__
     # Check if specified grid model exists and is not empty
     if grid_model.is_empty(realisation_number):
         raise ValueError(
@@ -566,7 +543,7 @@ def set_discrete_3d_parameter_values(
     parameter_name,
     input_values,
     code_names,
-    zone_numbers=None,
+    zone_indices=None,
     realisation_number=0,
     is_shared=False,
     debug_level=Debug.OFF,
@@ -578,7 +555,7 @@ def set_discrete_3d_parameter_values(
            input_values    - A numpy array of length equal to the number of active cells and with continuous values.
                            Only the grid cells belonging to the specified zones are updated even though the values array
                            contain values for all active cells.
-           zone_numbers - A list of integer values that are zone numbers (counted from 0). If the list is empty or has
+           zone_indices   - A list of integer values that are zone indices (counted from 0). If the list is empty or has
                           all zones included in the list, then grid cells in all zones are updated.
            code_names     - A dictionary with code names and code values for the discrete parameter values of the form as
                            in the example:
@@ -620,7 +597,7 @@ def set_discrete_3d_parameter_values(
             grid_model,
             input_values,
             parameter_name,
-            zone_numbers,
+            zone_indices,
             is_shared,
             realisation_number,
             code_names,
@@ -647,7 +624,7 @@ def set_discrete_3d_parameter_values(
             )
         current_values = p.get_values(realisation_number)
         current_values = modify_selected_grid_cells(
-            grid_model, zone_numbers, realisation_number, current_values, input_values
+            grid_model, zone_indices, realisation_number, current_values, input_values
         )
         p.set_values(current_values, realisation_number)
 
@@ -673,7 +650,7 @@ def _create_property(
     grid_model,
     values,
     parameter_name,
-    zone_numbers,
+    zone_indices,
     is_shared,
     realisation_number,
     code_names=None,
@@ -685,7 +662,7 @@ def _create_property(
     p = grid_model.properties.create(parameter_name, property_type, dtype)
     current_values = np.zeros(len(values), dtype)
     current_values = modify_selected_grid_cells(
-        grid_model, zone_numbers, realisation_number, current_values, values
+        grid_model, zone_indices, realisation_number, current_values, values
     )
     p.set_values(current_values, realisation_number)
     p.set_shared(is_shared, realisation_number)
@@ -741,7 +718,6 @@ def update_discrete_3d_parameter_values(
     :param debug_level: Specify how much info is to be printed to screen. (0 - almost nothing output to screen, 3 - much output to screen)
 
     """
-    function_name = update_discrete_3d_parameter_values.__name__
     # Check if specified grid model exists and is not empty
     if grid_model.is_empty(realisation_number):
         raise ValueError(

--- a/aps/utils/roxar/getGridModelAttributes.py
+++ b/aps/utils/roxar/getGridModelAttributes.py
@@ -7,11 +7,12 @@ This script will read grid dimensions of the grid for the specified grid model i
 
 from xml.etree.ElementTree import Element
 
-from aps.utils.roxar.grid_model import GridAttributes, get_zone_names
+from aps.utils.roxar.grid_model import GridAttributes
 from aps.algorithms.APSModel import APSModel
 from aps.utils.constants.simple import Debug
 from aps.utils.methods import get_run_parameters
 from aps.utils.xmlUtils import prettify
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 def writeXMLFileGridDimensions(
@@ -31,10 +32,12 @@ def writeXMLFileGridDimensions(
             f'Could not find grid model with name: {gridModelName} in RMS project'
         )
     # Get the grid
-    grid = gridModel.get_grid()
-    zone_names = get_zone_names(gridModel)
+    grid = gridModel.get_grid(project.current_realisation)
+    zone_mapping = ZoneMapping(
+        grid_model, grid, real_number=project.current_realisation
+    )
     # Get Grid attributes
-    grid_attributes = GridAttributes(grid, zone_names)
+    grid_attributes = GridAttributes(grid, zone_mapping)
 
     nx, ny, nz = grid_attributes.dimensions
     nx_simbox, ny_simbox, nz_simbox = grid_attributes.sim_box_size.simbox_dimensions

--- a/aps/utils/roxar/grid_model.py
+++ b/aps/utils/roxar/grid_model.py
@@ -11,7 +11,6 @@ from aps.utils.constants.simple import (
 )
 from aps.utils.decorators import cached
 from aps.utils.exceptions.general import raise_error
-from aps.utils.io import print_debug_information
 from aps.utils.methods import calc_average
 from roxar import Direction, GridPropertyType
 
@@ -39,6 +38,13 @@ def get_zone_names(grid_model):
     for _, value in code_names.items():
         zone_names.append(value)
     return zone_names
+
+
+def get_zone_code(code_names: dict, zone_name: str):
+    for code, name in code_names.items():
+        if name == zone_name:
+            return code
+    raise ValueError(f'Zone name :{zone_name} does not exist in zone parameter.')
 
 
 def find_defined_cells(
@@ -181,50 +187,39 @@ def average_of_property_inside_zone_region(
 def calcStatisticsFor3DParameter(
     grid_model,
     parameter_name,
-    zone_number_list,
+    zone_index_list,
+    zone_mapping,
+    zone_values,
     realization_number=0,
     debug_level=Debug.OFF,
 ):
+    # Is currently not used
     """
-    Calculates basic characteristics of property.
-    Calculates the basic statistics of the Property object provided.
-    TODO
-    Input:
-           property       - The Property object we wish to perform calculation on.
-
-    :param grid_model: TODO: property!
-    :param parameter_name: TODO: property!
-    :param zone_number_list:  List of zone numbers (counting from 0) for zones that
-                            are included in the min, max, average calculation. Empty
-                            list or list containing all zones will find
-                            min, max, average over all zones
-    :param realization_number: Realisation number counted from 0 for the parameter to get.
-    :param debug_level: TODO
-    :returns: tuple (minimum, maximum, average)
-        WHERE
-        float minimum is the minimum value
-        float maximum is the maximum value
-        float average is the average value
+    Calculates the basic statistics of the parameter provided.
+    zone_index_list is list of zone indices for grid model (counting from 0)
+    for zones that are included in the min, max, average calculation.
+    Empty list or list containing all zones will find min, max, average
+    over all zones.
+    Returns: tuple (minimum, maximum, average)
     """
     values = get_selected_grid_cells(
-        grid_model, parameter_name, zone_number_list, realization_number
+        grid_model,
+        parameter_name,
+        zone_index_list,
+        zone_values,
+        zone_mapping,
+        realization_number,
     )
     maximum = np.max(values)
     minimum = np.min(values)
     average = np.average(values)
 
     if debug_level >= Debug.VERY_VERBOSE:
-        function_name = calcStatisticsFor3DParameter.__name__
-        print_debug_information(
-            function_name,
-            (
-                f' Calculate min, max, average for parameter: {parameter_name}'
-                f'{" for selected zones" if len(zone_number_list) > 0 else ""} '
-            ),
+        print(
+            f'Calculate min, max, average for parameter: {parameter_name}'
+            f'{" for selected zones" if len(zone_index_list) > 0 else ""} '
         )
-        print_debug_information(
-            function_name, f' Min: {minimum}  Max: {maximum}  Average: {average}'
-        )
+        print(f' Min: {minimum}  Max: {maximum}  Average: {average}')
 
     return minimum, maximum, average
 
@@ -279,17 +274,23 @@ def getContinuous3DParameterValues(grid_model, parameter_name, realization_numbe
 
 
 def get_selected_grid_cells(
-    grid_model, parameter_name, zone_number_list, realization_number
+    grid_model,
+    parameter_name,
+    zone_index_list,
+    zone_values,
+    zone_mapping,
+    realization_number,
 ):
     """
     Input:
            grid_model     - Grid model object
            parameter_name - Name of 3D parameter to get.
 
-           zone_number_list - A list of integer values that are zone numbers (counted from 0).
+           zone_number_list - A list of integer values that are zone indices in the grid model (counted from 0).
                               If the list is empty or has all zones included in the list,
                               then grid cells in all zones are updated.
            realization_number    - Realisation number counted from 0 for the parameter to get.
+
     Output:
            Numpy vector with parameter values for the active cells belonging to the specified zones.
            Note that the output is in general not of the same length as a vector with all active cells.
@@ -297,18 +298,12 @@ def get_selected_grid_cells(
     all_values = getContinuous3DParameterValues(
         grid_model, parameter_name, realization_number
     )
-    if len(zone_number_list) > 0:
-        grid3d = grid_model.get_grid(realization_number)
-        # Get all zone values
-        zone_values, _ = _zone_parameter_values(grid3d)
-
+    if len(zone_index_list) > 0:
         # Get values for the specified zones
         index_array = np.arange(len(zone_values), dtype=np.uint64)
         first = True
-        for zone_number in zone_number_list:
-            zone_number += (
-                1  # Input zone numbering start at 0, but zone values start at 1
-            )
+        for zone_index in zone_index_list:
+            zone_number = zone_mapping.get_zone_number_for_zone_index(zone_index)
             cell_index_one_zone = index_array[(zone_values == zone_number)]
             if first:
                 cell_index_defined = cell_index_one_zone
@@ -412,21 +407,22 @@ def getDiscrete3DParameterValues(grid_model, parameter_name, realization_number=
 
 
 def modify_selected_grid_cells(
-    grid_model, zone_numbers, realization_number, old_values, new_values
+    grid_model, zone_indices_list, realization_number, old_values, new_values
 ):
-    """Updates an input numpy array old_values with values from the input numpy array new_values for those indices
-    that corresponds to grid cells in the zones defined in the zone_number_list.
-    If the list of zone numbers is empty, this means that ALL zones are updated,
+    """Updates an input numpy array old_values with values from the
+    input numpy array new_values for those indices
+    that corresponds to grid cells in the zones defined in the zone_indices_list.
+    If the list of zone indices is empty, this means that ALL zones are updated,
     and has the same effect as if all zones are specified in the list.
     """
     grid = grid_model.get_grid(realization_number)
     indexer = grid.simbox_indexer
     dim_i, dim_j, _ = indexer.dimensions
-    if zone_numbers is None:
-        zone_numbers = []
-    if len(zone_numbers) > 0:
+    if zone_indices_list is None:
+        zone_indices_list = []
+    if len(zone_indices_list) > 0:
         for zone_index in indexer.zonation:
-            if zone_index in zone_numbers:
+            if zone_index in zone_indices_list:
                 layer_ranges = indexer.zonation[zone_index]
                 for lr in layer_ranges:
                     # Get all the cell numbers for the layer range
@@ -510,33 +506,42 @@ def get_zone_layer_numbering(grid):
 
 
 def get_simulation_box_thickness(
-    grid, zone=None, debug_level=Debug.OFF, max_number_of_selected_cells=1000
+    grid,
+    zone_mapping,
+    zone_index_input=None,
+    debug_level=Debug.OFF,
+    max_number_of_selected_cells=1000,
 ):
     # Check if API has simboxthickness access
+    # Input grid3D object, dict with zone number and names,
+    # Return a dict thickness_per_zone
     try:
         thickness_per_zone = {}
         simbox = grid.simbox
         simbox_increments_dict = simbox.cell_increments
         simbox_increments = simbox_increments_dict['z_increments']
-        number_of_layers_per_zone, _, _ = get_zone_layer_numbering(grid)
-        for zindx, nlayer in enumerate(number_of_layers_per_zone):
-            zone_number = zindx + 1
-            thickness_per_zone[zone_number] = simbox_increments[zindx] * nlayer
+        number_of_layers_per_zone = zone_mapping.get_number_of_layers_per_zone()
+        # Find thickness in number of layers per defined zone in the grid
+        # Use zone_code_names to get zone_number for the zone
         if debug_level >= Debug.VERBOSE:
             print(
                 '-- Get simbox thickness using Roxar API for RMS version 14.1.0 or later'
             )
+        for z_indx, n_layer in enumerate(number_of_layers_per_zone):
+            zone_number = zone_mapping.get_zone_number_for_zone_index(z_indx)
+            value = simbox_increments[z_indx] * n_layer
+            thickness_per_zone[zone_number] = value
             if debug_level >= Debug.VERY_VERBOSE:
-                for zone_number, value in thickness_per_zone.items():
-                    print(
-                        f'--- Zone: {zone_number} sim box thickness: {value}  nlayers: {number_of_layers_per_zone[zone_number - 1]} '
-                    )
+                print(
+                    f'--- Zone: {zone_number} sim box thickness: {value}  nlayers: {n_layer} '
+                )
 
     except AttributeError:
         # For RMS version earlier than 14.1
         thickness_per_zone = get_simulation_box_thickness_estimate(
             grid,
-            zone=zone,
+            zone_mapping,
+            zone_index_input=zone_index_input,
             debug_level=Debug.OFF,
             max_number_of_selected_cells=max_number_of_selected_cells,
         )
@@ -550,7 +555,11 @@ def get_simulation_box_thickness(
 
 
 def get_simulation_box_thickness_estimate(
-    grid, zone=None, debug_level=Debug.OFF, max_number_of_selected_cells=1000
+    grid,
+    zone_mapping,
+    zone_index_input=None,
+    debug_level=Debug.OFF,
+    max_number_of_selected_cells=1000,
 ):
     """Estimate simulation box thickness for each zone.
     This is done by assuming that it is sufficient to calculate difference
@@ -566,9 +575,10 @@ def get_simulation_box_thickness_estimate(
     indexer = grid.grid_indexer
     dim_i, dim_j, _ = indexer.dimensions
     zone_indices = indexer.zonation
-    if zone is not None:
-        zone_indices = [zone]
+    if zone_index_input is not None:
+        zone_indices = [zone_index_input]
     for zone_index in zone_indices:
+        zone_number = zone_mapping.get_zone_number_for_zone_index(zone_index)
         layer_ranges = indexer.zonation[zone_index]
         zone_cell_numbers_top_layer = None
         n_cell_columns_active_selected = 0
@@ -616,7 +626,7 @@ def get_simulation_box_thickness_estimate(
             if debug_level >= Debug.VERY_VERBOSE:
                 print(
                     f'--- Zone number, layer_ranges, top layer for thickness calculation: '
-                    f'{zone_index + 1}  {layer_ranges}   {k_top}'
+                    f'{zone_number}  {layer_ranges}   {k_top}'
                 )
 
             for k in range(kmax, kmin - 1, -1):
@@ -628,7 +638,7 @@ def get_simulation_box_thickness_estimate(
             if debug_level >= Debug.VERY_VERBOSE:
                 print(
                     f'--- Zone number, layer_ranges, base layer for thickness calculation: '
-                    f'{zone_index + 1}  {layer_ranges}   {k_base}'
+                    f'{zone_number}  {layer_ranges}   {k_base}'
                 )
 
             # For this layer range, pick arbitrarily max_number_of_selected_cells among the defined grid cells
@@ -636,10 +646,10 @@ def get_simulation_box_thickness_estimate(
             if n_cells_active_in_zone_top <= 0:
                 if debug_level >= Debug.VERY_VERBOSE:
                     warn(
-                        f'Zone number {zone_index + 1}  layer range {lr}  has no active cells'
+                        f'Zone number {zone_number}  layer range {lr}  has no active cells'
                     )
                     warn(
-                        f'Skipping the ranges {lr.start} - {lr.stop}, for zone number "{zone_index + 1}".'
+                        f'Skipping the ranges {lr.start} - {lr.stop}, for zone number "{zone_number}".'
                         f' They are not defined'
                     )
                 continue
@@ -697,7 +707,7 @@ def get_simulation_box_thickness_estimate(
                     n_cell_columns_inactive_this_layer_range += 1
 
             if debug_level >= Debug.VERY_VERBOSE:
-                print(f'--- Zone number {zone_index + 1}  layer range {lr}:')
+                print(f'--- Zone number {zone_number}  layer range {lr}:')
                 print(
                     f'     Selected number of active cell columns: {n_cell_columns_active_this_layer_range}'
                 )
@@ -709,9 +719,9 @@ def get_simulation_box_thickness_estimate(
 
         if has_no_active_cells_in_zone:
             # There are no active cells in this zone
-            thickness_per_zone[zone_index + 1] = SimBoxThicknessConstants.DEFAULT_VALUE
+            thickness_per_zone[zone_number] = SimBoxThicknessConstants.DEFAULT_VALUE
             warn(
-                f'Zone number {zone_index + 1}: No active grid cells.\n'
+                f'Zone number {zone_number}: No active grid cells.\n'
                 f'Use default zone thickness: {SimBoxThicknessConstants.DEFAULT_VALUE}'
             )
         else:
@@ -722,7 +732,7 @@ def get_simulation_box_thickness_estimate(
                 )
                 if debug_level >= Debug.VERY_VERBOSE:
                     print(
-                        f'--- Zone number: {zone_index + 1}   Estimated sim box thickness {average_thickness}'
+                        f'--- Zone number: {zone_number}   Estimated sim box thickness {average_thickness}'
                     )
             else:
                 average_thickness = (
@@ -730,14 +740,14 @@ def get_simulation_box_thickness_estimate(
                     + sum_thickness_for_selected_inactive_cell_columns
                 ) / (n_cell_columns_active_selected + n_cell_columns_inactive_selected)
                 if debug_level >= Debug.VERY_VERBOSE:
-                    print(f'--- Zone number: {zone_index + 1}:')
+                    print(f'--- Zone number: {zone_number}:')
                     print(
                         '    When estimating sim box thickness, '
                         'use also cell columns where either top or base grid cell is inactive.'
                     )
                     print(f'    Estimated sim box thickness: {average_thickness}')
 
-            thickness_per_zone[zone_index + 1] = average_thickness
+            thickness_per_zone[zone_number] = average_thickness
 
     return thickness_per_zone
 
@@ -1038,7 +1048,6 @@ class GridSimBoxSize:
         x0, y0 = self.estimated_origo()
         cell_center_xyz = np.zeros((ncells, 3), dtype=np.float32)
         if self.ijk_handedness == Direction.right:
-            # j_index = ny - 1 - j
             y = (-ijk_cell_indices[:, 1] + self.simbox_ny - 1 + 0.5) * yinc
         else:
             y = (ijk_cell_indices[:, 1] + 0.5) * yinc
@@ -1051,22 +1060,21 @@ class GridSimBoxSize:
 
 
 class GridAttributes:
-    def __init__(self, grid, zone_names, debug_level=Debug.OFF):
+    def __init__(self, grid, zone_mapping, debug_level=Debug.OFF):
         self.grid = grid
         self.debug_level = debug_level
-        self._zone_names = zone_names
+        self._zone_names_dict = zone_mapping.get_zone_names_from_param()
+
         if self.debug_level >= Debug.VERY_VERBOSE:
-            print('Min. X: {}   | Max. X: {}'.format(self.xmin, self.xmax))
-            print('Min. Y: {}   | Max. Y: {}'.format(self.ymin, self.ymax))
-            print('Min. Z: {}   | Max. Z: {}'.format(self.zmin, self.zmax))
+            print(f'Min. X: {self.xmin}   | Max. X: {self.xmax}')
+            print(f'Min. Y: {self.ymin}   | Max. Y: {self.ymax}')
+            print(f'Min. Z: {self.zmin}   | Max. Z: {self.zmax}')
             print('------------------------------------------------')
 
             # Get number of cells
             nx, ny, nz = self.dimensions
             nx_simbox, ny_simbox, nz_simbox = self.simbox_dimensions
             total_cells = nx * ny * nz
-
-            # Get Zone names
 
             print('Total no. of cells:', total_cells)
             print('No. of defined cells:', self.grid.defined_cell_count)
@@ -1086,24 +1094,21 @@ class GridAttributes:
             print('\n')
             print('No. of zones:', self.num_zones)
             print('------------------------------------------------')
-            for i, zone_index in enumerate(
-                self.simbox_indexer.zonation.keys(), start=1
-            ):
+            for zone_index in list(self.simbox_indexer.zonation.keys()):
                 # Only one interval of layers per zone for grid layers in sim box
                 assert len(self.simbox_indexer.zonation[zone_index]) == 1
-                layer_range = self.simbox_indexer.zonation[zone_index]
-                start, *_, end = layer_range[0]
+                zone_number = zone_mapping.get_zone_number_for_zone_index(zone_index)
+                start, end = zone_mapping.get_start_end_layer_for_zone_index(zone_index)
                 num_layers_in_zone = end + 1 - start
-                # Indexes start with 0, so add 1 to give user-friendly output
                 print(
-                    f'Zone number: {zone_index + 1}, '
+                    f'Zone number: {zone_number}, '
                     f'Layers {start + 1}-{end + 1} ({num_layers_in_zone} layers)\n'
                 )
 
     @property
     @cached
     def num_zones(self):
-        return len(self._zone_names)
+        return len(self._zone_names_dict)
 
     @property
     @cached
@@ -1152,7 +1157,7 @@ class GridAttributes:
     @property
     @cached
     def zone_names(self):
-        return self._zone_names
+        return list(self._zone_names_dict.values())
 
     @property
     @cached
@@ -1236,17 +1241,17 @@ def create_zone_parameter(
                 )
 
         if zone_parameter.is_empty(realisation=realization_number) or create_new:
-            if debug_level >= Debug.VERY_VERBOSE:
+            if debug_level >= Debug.VERBOSE:
                 if not create_new:
                     print(
-                        f'--- Zone parameter is empty. Assign values to: {zone_parameter.name}'
+                        f'-- Zone parameter is empty. Assign values to: {zone_parameter.name}'
                     )
             # Fill the parameter with zone values, but don't change the code_names
             values, _ = _zone_parameter_values(grid3d)
             zone_parameter.set_values(values, realisation=realization_number)
     else:
-        if debug_level >= Debug.VERY_VERBOSE:
-            print(f'--- Create zone parameter with name {name}')
+        if debug_level >= Debug.ON:
+            print(f'- Create zone parameter with name {name}')
         # Create zone parameter connected to the grid model
         zone_parameter = properties.create(
             name, property_type=GridPropertyType.discrete, data_type=np.uint16
@@ -1262,7 +1267,7 @@ def create_zone_parameter(
 def _zone_parameter_values(grid3d, debug_level=Debug.OFF):
     """Description: Return numpy array for the active grid cells with
     zone number in each grid cell.
-    Note: This function is meant to create new zone paraneter
+    Note: This function is meant to create new zone parameter
     from the grid instance if it does not exist.
     Therefore, this function access the grid3d.zone_names
     to get the zone names. But for all other functions

--- a/aps/utils/roxar/job.py
+++ b/aps/utils/roxar/job.py
@@ -24,6 +24,7 @@ from aps.utils.roxar.progress_bar import APSProgressBar
 from aps.utils.check_rms_interactive_or_batch import check_rms_execution_mode
 
 from fmu.tools.rms.copy_rms_param_to_ertbox_grid import check_grid_layout
+from fmu.tools.rms.zone_mapping import ZoneMapping
 
 
 def excepthook(type, value, traceback):
@@ -130,9 +131,17 @@ class JobConfig:
                         f'This is required, when running in ERT / AHM.'
                     )
                 else:
+                    grid_model = self.project.grid_models[aps_model.grid_model_name]
+                    grid = grid_model.get_grid(self.project.current_realisation)
+                    zone_mapping = ZoneMapping(
+                        grid_model, grid, self.project.current_realisation
+                    )
+                    zone_name = zone_mapping.get_zone_name_for_zone_number(
+                        zone_model.zone_number
+                    )
                     check_grid_layout(
                         aps_model.grid_model_name,
-                        zone_model.zone_number,
+                        zone_name,
                         zone_model.grid_layout.value,
                         aps_job_name=self.roxar.rms.get_running_job_name(),
                         return_grid_layout=False,

--- a/aps/utils/roxar/rms_project_data.py
+++ b/aps/utils/roxar/rms_project_data.py
@@ -38,7 +38,6 @@ from aps.utils.constants.simple import (
     OriginType,
     ProbabilityTolerances,
     CrossSectionType,
-    GridModelConstants,
 )
 from aps.utils.debug import parse_dot_master
 from aps.utils.exceptions.xml import ApsXmlError
@@ -52,6 +51,7 @@ from aps.utils.roxar.grid_model import (
     GridSimBoxSize,
     get_zone_names,
 )
+from fmu.tools.rms.zone_mapping import ZoneMapping
 from aps.utils.facies_map import create_facies_map
 from aps.utils.roxar.migrations import Migration
 from aps.utils.roxar.progress_bar import APSProgressBar
@@ -248,12 +248,10 @@ class RMSData:
         self, grid_model_name: GridName, rough: bool = False
     ) -> dict:
         grid = self.get_grid(grid_model_name)
+        grid_model = self.get_grid_model(grid_model_name)
+        zone_mapping = ZoneMapping(grid_model, grid)
         sim_box_attributes = GridSimBoxSize(grid)
-        kwargs = {}
-        if rough:
-            kwargs['max_number_of_selected_cells'] = 10
-
-        sim_box_z_length = get_simulation_box_thickness(grid, **kwargs)
+        sim_box_z_length = get_simulation_box_thickness(grid, zone_mapping)
         return {
             'size': {
                 'x': sim_box_attributes.x_length,
@@ -287,22 +285,20 @@ class RMSData:
     def get_zones(self, grid_model_name: GridName) -> List[dict]:
         grid = self.get_grid(grid_model_name)
         grid_model = self.get_grid_model(grid_model_name)
-        zone_names = get_zone_names(grid_model)
-        if len(zone_names) == 0:
-            name = GridModelConstants.ZONE_NAME
-            warn(
-                f"No zone parameter with name '{name}' found. Create zone parameter from grid."
-            )
-            create_zone_parameter(grid_model)
-            zone_names = get_zone_names(grid_model)
+        zone_mapping = ZoneMapping(grid_model, grid, self.project.current_realisation)
+
+        # Get existing zone parameter or create a new one if not existing
+        nzones = zone_mapping.get_number_of_zones_in_grid()
         zones = []
-        for key, zonations in grid.simbox_indexer.zonation.items():
-            zonation, *_reverse = zonations
+        for zone_index in range(nzones):
+            zone_name = zone_mapping.get_zone_name_for_zone_index(zone_index)
+            zone_number = zone_mapping.get_zone_number_for_zone_index(zone_index)
+            nlayers = zone_mapping.number_of_layers_for_zone_index(zone_index)
             zones.append(
                 {
-                    'code': key + 1,
-                    'name': zone_names[key],
-                    'thickness': zonation.stop - zonation.start,
+                    'code': zone_number,
+                    'name': zone_name,
+                    'thickness': nlayers,
                 }
             )
         return zones

--- a/aps/utils/roxar/test_sample_map_to_grid.py
+++ b/aps/utils/roxar/test_sample_map_to_grid.py
@@ -3,10 +3,9 @@
 JRIV/OLIA
 """
 
-import numpy as np
-import xtgeo
 from aps.algorithms.APSModel import APSModel
 from aps.utils.roxar.sample_map_to_grid import trend_map_to_grid_param
+from aps.utils.constants.simple import Debug
 
 
 def run(*, project, zone_number, **kwargs):

--- a/aps/utils/trend.py
+++ b/aps/utils/trend.py
@@ -263,9 +263,6 @@ def add_trends_to_field(
             gauss_field_values_all,
             cell_index_defined,
             realization_number,
-            use_regions=use_regions,
-            zone_number=zone_number,
-            region_number=region_number,
             debug_level=debug_level,
             is_shared=is_shared,
         )
@@ -279,9 +276,6 @@ def add_trends_to_field(
             cell_index_defined,
             realization_number,
             variable_name_extension='residual',
-            use_regions=use_regions,
-            zone_number=zone_number,
-            region_number=region_number,
             debug_level=debug_level,
             is_shared=is_shared,
         )
@@ -296,9 +290,6 @@ def add_trends_to_field(
             cell_index_defined,
             realization_number,
             variable_name_extension='trend',
-            use_regions=use_regions,
-            zone_number=zone_number,
-            region_number=region_number,
             debug_level=debug_level,
             is_shared=is_shared,
         )


### PR DESCRIPTION
Purpose of this change is to ensure that APS uses the zone number used in the zone parameter in case this is coming from another multizone grid that is split into single zone grids and where zone parameter is inherited from the multizone grid.

### Reasons for making this change

A workflow where zone parameter gets zone numbers not following the default order starting at 1 for upper zone and increasing downwards, there will be a mismatch in the zone number used by APS and the zone number in the zone parameter. To avoid this, let APS always use an existing zone parameter's code-name table to set zone number of reach zone. If the zone parameter does not exist, APS will create it per default and start zone numbering at 1 for uppermost zone.

Closes: #78 
