### PR TITLE
Fixed write file in unit tests

### DIFF
--- a/aps/unit_test/helpers.py
+++ b/aps/unit_test/helpers.py
@@ -40,12 +40,13 @@ def apply_truncations(
     faciesOutputFile: str,
     debug_level: Debug = Debug.OFF,
 ) -> None:
+    print('In apply_truncations')
     assert truncRule is not None
     assert faciesReferenceFile != ''
     nGaussFieldsInModel = truncRule.getNGaussFieldsInModel()
     if debug_level >= Debug.ON:
-        print('nGaussFieldsInModel: ' + str(nGaussFieldsInModel))
-        print('nGaussFields: ' + str(nGaussFields))
+        print('  nGaussFieldsInModel: ' + str(nGaussFieldsInModel))
+        print('  nGaussFields: ' + str(nGaussFields))
     assert nGaussFieldsInModel == nGaussFields
     alphaFields = []
     fileName = gaussFieldFiles[0]
@@ -57,8 +58,8 @@ def apply_truncations(
         alphaFields.append(a)
         assert nValues == len(alphaFields[n])
     if debug_level >= Debug.ON:
-        print('nValues: ' + str(nValues))
-        print('nx,ny,nx*ny: ' + str(nx) + ' ' + str(ny) + ' ' + str(nx * ny))
+        print('  nValues: ' + str(nValues))
+        print('  nx,ny,nx*ny: ' + str(nx) + ' ' + str(ny) + ' ' + str(nx * ny))
     alphaCoord = {}
     faciesReal = []
     # Loop through the Gaussian field array in c-index ordering
@@ -70,21 +71,21 @@ def apply_truncations(
         faciesReal.append(faciesCode)
     if debug_level >= Debug.ON:
         print(
-            'Number of shifts in alpha values for numerical reasons: '
+            '  Number of shifts in alpha values for numerical reasons: '
             + str(truncRule.getNCountShiftAlpha())
         )
     writeFile(faciesOutputFile, faciesReal, nx, ny)
 
     # Compare the generated facies realization with the reference for this case
-    check = compare(faciesOutputFile, faciesReferenceFile)
-    print(f'Compare file: {faciesReferenceFile} and file: {faciesOutputFile}')
+    check = compare(faciesOutputFile, faciesReferenceFile, verbose=False)
+    print(f'  Compare file: {faciesReferenceFile} and file: {faciesOutputFile}')
     if check is False:
         fileName = faciesReferenceFile + '_' + faciesOutputFile + '.tmp'
         os.rename(faciesOutputFile, fileName)
-        print('Write file: {}'.format(fileName))
-        raise ValueError('Error: Files are different')
+        print('  Write file: {}'.format(fileName))
+        raise ValueError('  Error: Files are different')
     elif debug_level >= Debug.ON:
-        print('Files are equal: OK')
+        print('  Files are equal: OK')
 
 
 def apply_truncations_vectorized(
@@ -95,12 +96,13 @@ def apply_truncations_vectorized(
     faciesOutputFile: str,
     debug_level: Debug = Debug.OFF,
 ) -> None:
+    print('In apply_truncations_vectorized')
     assert truncRule is not None
     assert faciesReferenceFile != ''
     nGaussFieldsInModel = truncRule.getNGaussFieldsInModel()
     if debug_level >= Debug.ON:
-        print('nGaussFieldsInModel: ' + str(nGaussFieldsInModel))
-        print('nGaussFields: ' + str(nGaussFields))
+        print('  nGaussFieldsInModel: ' + str(nGaussFieldsInModel))
+        print('  nGaussFields: ' + str(nGaussFields))
     assert nGaussFieldsInModel == nGaussFields
     alphaFields = []
     fileName = gaussFieldFiles[0]
@@ -112,8 +114,8 @@ def apply_truncations_vectorized(
         alphaFields.append(a)
         assert nValues == len(alphaFields[n])
     if debug_level >= Debug.ON:
-        print('nValues: ' + str(nValues))
-        print('nx,ny,nx*ny: ' + str(nx) + ' ' + str(ny) + ' ' + str(nx * ny))
+        print('  nValues: ' + str(nValues))
+        print('  nx,ny,nx*ny: ' + str(nx) + ' ' + str(ny) + ' ' + str(nx * ny))
     alphaCoord_vectors = np.zeros((nValues, nGaussFields), np.float32)
     # Loop through the Gaussian field array in c-index ordering
     for n in range(nGaussFields):
@@ -123,27 +125,23 @@ def apply_truncations_vectorized(
         alphaCoord_vectors
     )
 
-    if debug_level >= Debug.ON:
+    if debug_level >= Debug.VERBOSE:
         print(
-            'Number of shifts in alpha values for numerical reasons: '
+            '  Number of shifts in alpha values for numerical reasons: '
             + str(truncRule.getNCountShiftAlpha())
         )
-        print('facies realization:')
-        print(faciesCode_vector)
-        print(len(faciesCode_vector))
-    print(faciesOutputFile)
     writeFile(faciesOutputFile, faciesCode_vector, nx, ny)
 
     # Compare the generated facies realization with the reference for this case
     check = compare(faciesOutputFile, faciesReferenceFile)
-    print(f'Compare file: {faciesReferenceFile} and file: {faciesOutputFile}')
+    print(f'  Compare file: {faciesReferenceFile} and file: {faciesOutputFile}')
     if check is False:
         fileName = f'{faciesReferenceFile}_{faciesOutputFile}.tmp'
         os.rename(faciesOutputFile, fileName)
-        print(f'Write file: {fileName}')
-        raise ValueError('Error: Files are different')
+        print(f'  Write file: {fileName}')
+        raise ValueError('  Error: Files are different')
     elif debug_level >= Debug.ON:
-        print('Files are equal: OK')
+        print('  Files are equal: OK')
 
 
 def truncMapPolygons(
@@ -168,13 +166,14 @@ def truncMapPolygons(
     writePolygons(outPolyFile2, polygons)
 
     # Compare the original xml file created in createTrunc and the xml file written by interpretXMLModelFileAndWrite
+    print('In truncMapPolygons')
     check = compare(outPolyFile1, outPolyFile2)
-    print(f'Compare file: {outPolyFile1} and file: {outPolyFile2}')
+    print(f'  Compare file: {outPolyFile1} and file: {outPolyFile2}')
     assert check is True
     if check is False:
-        raise ValueError('Error: Files are different')
+        raise ValueError('  Error: Files are different')
     else:
-        print('Files are equal: OK')
+        print('  Files are equal: OK')
 
 
 def writePolygons(fileName: str, polygons: Any, debug_level: Debug = Debug.OFF) -> None:

--- a/aps/unit_test/test_Trunc2D_Angle_xml.py
+++ b/aps/unit_test/test_Trunc2D_Angle_xml.py
@@ -47,10 +47,6 @@ def interpretXMLModelFileAndWrite(
     truncRuleName = trRule[0].tag
     print('Truncation rule: ' + truncRuleName)
 
-    # Get number of required Gauss fields
-    nGaussFields = int(trRule[0].get('nGFields'))
-    # print('Number of gauss fields required for truncation rule: ' + str(nGaussFields))
-
     mainFaciesTable = APSMainFaciesTable(facies_table=fTable)
 
     # Create truncation rule object from input data, not read from file
@@ -150,6 +146,7 @@ def initialize_write_read(
     #    truncRule.writeContentsInDataStructure()
     # Read the previously written file as and XML file and write it out again to a new file
     # Global variable truncRule2
+    print('In initialize_write_read')
     truncRuleB = interpretXMLModelFileAndWrite(
         inputFile,
         file2,
@@ -161,13 +158,14 @@ def initialize_write_read(
     )
 
     # Compare the original xml file created in createTrunc and the xml file written by interpretXMLModelFileAndWrite
+    print('  Compare xml file created with xml written')
     check = filecmp.cmp(file1, file2)
-    print('Compare file: {} and file: {}'.format(file1, file2))
+    print(f'  Compare file: {file1} and file: {file2}')
     assert check is True
     if not check:
-        raise ValueError('Error: Files are different')
+        raise ValueError('  Error: Files are different')
     else:
-        print('Files are equal: OK')
+        print('  Files are equal: OK')
     return truncRuleA, truncRuleB
 
 
@@ -179,7 +177,6 @@ def getClassName(truncRule):
 
 
 def test_Trunc2DAngle():
-    nCase = 9
     start = 1
     end = 9
     for testCase in range(start, end + 1):
@@ -277,8 +274,6 @@ def test_case_3():
     overlayGroup = [alphaList, backgroundList]
     overlayGroups.append(overlayGroup)
 
-    faciesProb = [0.3, 0.2, 0.3, 0.1, 0.1]
-    faciesReferenceFile = get_facies_reference_file_path(3)
     run(
         fTable={1: 'F1', 2: 'F2', 3: 'F3', 4: 'F4', 5: 'F5'},
         faciesInZone=['F2', 'F3', 'F1', 'F5', 'F4'],

--- a/aps/utils/io.py
+++ b/aps/utils/io.py
@@ -94,16 +94,16 @@ def _write_file(file_name, data, heading, debug_level):
         text += str(point) + '  '
         count += 1
         if count >= 5:
+            text = text.strip()
             text += '\n'
             output += text
             count = 0
             text = ''
+    text = text.strip()
     if count > 0:
         output += text + '\n'
     with open(file_name, 'w', encoding='utf-8') as file:
         file.write(output)
-    if debug_level >= Debug.ON:
-        print(f'Write file: {file_name}')
 
 
 def print_debug_information(function_name: str, text: str) -> None:


### PR DESCRIPTION
### Reasons for making this change

Unit tests failed. Reason was that an additional blank character was written to computed files compared with reference files.

Closes: #91