### PR TITLE
Improve accessing project in development

### DIFF
--- a/aps/api/app.py
+++ b/aps/api/app.py
@@ -34,23 +34,20 @@ def favicon():
     return ''
 
 
-if __name__ == 'app':
-    # That is on when flask loads the app
-    try:
-        project
-    except NameError:
-        if 'RMS_PROJECT_PATH' in environ:
-            # Ensure "project" is available as a global variable
-            # similar to what ui.py expects
-            import roxar
+try:
+    project
+except NameError:
+    if 'RMS_PROJECT_PATH' in environ:
+        # Ensure "project" is available as a global variable
+        # similar to what ui.py expects
+        import roxar
 
-            __builtins__ = globals()['__builtins__']  # load the module
-            if 'project' not in __builtins__:
-                __builtins__['project'] = roxar.Project.open(
-                    environ['RMS_PROJECT_PATH']
-                )
-        else:
-            raise RuntimeError('No project available, and RMS_PROJECT_PATH is not set')
+        project = roxar.Project.open(environ['RMS_PROJECT_PATH'])
+        __builtins__ = globals()['__builtins__']  # load the module
+        if not hasattr(__builtins__, 'project'):
+            setattr(__builtins__, 'project', project)
+    else:
+        raise RuntimeError('No project available, and RMS_PROJECT_PATH is not set')
 
 
 if __name__ == '__main__':

--- a/aps/api/app.py
+++ b/aps/api/app.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import atexit
 from os import environ, urandom
 
 from flask import Flask, jsonify, request
@@ -48,6 +49,14 @@ except NameError:
             setattr(__builtins__, 'project', project)
     else:
         raise RuntimeError('No project available, and RMS_PROJECT_PATH is not set')
+
+
+@atexit.register
+def shutdown():
+    try:
+        project.close()
+    except NameError:
+        pass
 
 
 if __name__ == '__main__':

--- a/aps/api/app.py
+++ b/aps/api/app.py
@@ -35,28 +35,32 @@ def favicon():
     return ''
 
 
+def _ensure_project_is_available(rms_project: str):
+    import roxar
+
+    project = roxar.Project.open(rms_project)
+    __builtins__ = globals()['__builtins__']  # load the module
+    if not hasattr(__builtins__, 'project'):
+        setattr(__builtins__, 'project', project)
+
+
 try:
     project
 except NameError:
     if 'RMS_PROJECT_PATH' in environ:
         # Ensure "project" is available as a global variable
         # similar to what ui.py expects
-        import roxar
-
-        project = roxar.Project.open(environ['RMS_PROJECT_PATH'])
-        __builtins__ = globals()['__builtins__']  # load the module
-        if not hasattr(__builtins__, 'project'):
-            setattr(__builtins__, 'project', project)
+        _ensure_project_is_available(environ['RMS_PROJECT_PATH'])
     else:
         raise RuntimeError('No project available, and RMS_PROJECT_PATH is not set')
 
 
 @atexit.register
 def shutdown():
-    try:
+    __builtins__ = globals()['__builtins__']
+    project = getattr(__builtins__, 'project', None)
+    if project:
         project.close()
-    except NameError:
-        pass
 
 
 if __name__ == '__main__':

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 'roxenv'
       - 'poetry'
       - 'run'
-      - 'python'
+      - 'python3'
       - 'aps/api/app.py'
       - 'run'
       - '--host'


### PR DESCRIPTION
### Reasons for making this change

Makes it easier to deal with the global `project` variable from RMS when running the plugin locally.
