### PR TITLE
Enable dependabot for keeping packages up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: '/'
+    schedule:
+      interval: monthly
+    groups:
+      python:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: '/gui/'
+    schedule:
+      interval: monthly
+    groups:
+      npm:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: devcontainers
+    directory: '/.devcontainer/'
+    schedule:
+      interval: monthly


### PR DESCRIPTION
### Reasons for making this change

We have stoped using snyk.
This will allow us to get PRs for non-critical updates to our packages.

I've set the interval to be monthly.
