### PR TITLE
fix: Execute task via `mise`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+
       - uses: actions/download-artifact@v5
         with:
           pattern: build-artifacts-*
@@ -33,6 +37,6 @@ jobs:
 
       - name: Publish the APS-Facies plugin to GitHub
         run: |
-          ./.mise-tasks/publish ${{ startsWith(github.ref, 'refs/tags/v') && '--stable' || '' }}
+          mise tasks run publish ${{ startsWith(github.ref, 'refs/tags/v') && '--stable' || '' }}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Reasons for making this change

Forgot to update the action which uses `publish` after  50482a51bba46bfcaeac5ef1ed6cf3bd1ced83ac.


### Related merge requests

* #143
