### PR TITLE
[fix] Install yarn via `corepack` rather than `mise`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,4 @@
 nodejs     20.19.3
 python     3.11.13
-yarn       1.22.22
 pre-commit 4.1.0
 uv         0.8.22

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,11 @@ sources = ["pyproject.toml", "uv.lock"]
 outputs = [".venv/"]
 
 [tasks."dependencies:node"]
-run = "yarn install --frozen-lockfile"
+run = """
+corepack enable
+corepack install
+yarn install --frozen-lockfile
+"""
 dir = "gui"
 sources = ["gui/package.json", "gui/yarn.lock"]
 outputs = ["gui/node_modules/"]


### PR DESCRIPTION
### Reasons for making this change

`yarn` is no longer supported in `.tool-version` for `mise`. We have already pinned the version in `gui/package.json`, so we can just use that one directly


### Related merge requests

Created because of how #163 failed to build

