### PR TITLE
Only allow reading while building

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -6,6 +6,9 @@ on:
         default: false
         description: 'Toggles whether a stable (full release) or a beta should be build'
 
+permissions:
+  contents: read
+
 jobs:
   build-gui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Reasons for making this change

Should resolve the security issue mentioned by GitHub Advanced Security
