### PR TITLE
May run tests in an internal RMS environment

### DIFF
--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [[ "${TRACE:-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+function run_tests() {
+    # The entrypoint as seen by Equinor's internal RMS testing framework
+    install_dependencies
+
+    pytest "$PROJECT_ROOT/tests"
+}
+
+function install_dependencies() {
+    pushd "$PROJECT_ROOT" >/dev/null || exit 1
+    pip install .
+}


### PR DESCRIPTION
### Reasons for making this change

Implements the necessary scripts for having our unit tests be executed in an environment with RMS installed

Requires #109 to be implemented