### PR TITLE
 The version is removed when executing `uv sync`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,6 @@ resolution-markers = [
 
 [[package]]
 name = "aps"
-version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fmu-tools" },


### PR DESCRIPTION
### Reasons for making this change

Regression from bca1655a0130433a91e1c9cedd3a1d6b2d2f8901 That is, this change should have been part of that commit



### Related merge requests

* #109 

