### PR TITLE
[hotfix] Use version 3 of `jdx/mise`

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         # We include the creation and edit time in the documentation, so we need the full history
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v3
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v3
         with:
           install: false
 


### PR DESCRIPTION
### Reasons for making this change

This version is used elsewhere in the workflows, and was removed from allowed workflows.

None of the deployments have succeeded since the 1st of October (#150)


### Related merge requests

* #150
