### PR TITLE
Add a home page to the documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+---
+title: Home
+---
+
+Welcome to the documentation for the Adaptive Pluri-Gaussian Simulation (APS) plugin for [Aspen RMS<sup>&reg;</sup>](https://www.aspentech.com/en/products/sse/aspen-rms).
+It is developed for and by [Equinor](https://www.equinor.com) under the [Apache license](https://www.apache.org/licenses/LICENSE-2.0), which means you are free to use and adapt it, free of charge, for commercial and non-commercial purposes.
+Contributions are welcome.
+
+It is based on the method published by B. Sebacher et al. ([Journal of Petroleum Science and Engineering, Vol. 158, September 2017, p. 494-508](https://www.sciencedirect.com/science/article/pii/S0920410517300505)) and is extended to handle trends in Gaussian Random Fields and multiple overlay facies.
+
+The plugin is compatible with [Fast Model Update (FMU)](https://github.com/equinor/fmu-tools) and [Ensemble based Reservoir Tool (ERT)](https://github.com/equinor/ert) workflows in RMS to do assisted history matching.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_name: equinor/APS-Facies
 edit_uri: 'edit/main/docs/'
 
 nav:
+  - index.md
   - APS user guide:
       - aps-user-guide/README.md
       - Define APS Job:


### PR DESCRIPTION
### Reasons for making this change

Adds a home page for the documentation so that https://equinor.github.io/APS-Facies/ no loger shows "Page not found"

### Related issues

* Should be include before #192. 

### Checklist

<!--Check those applicable, and remove those that are not.-->

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the help directory with an example use of the feature
