### PR TITLE
[HOTFIX] Use consistent argument

### DIFF
--- a/.mise-tasks/build-gui
+++ b/.mise-tasks/build-gui
@@ -116,7 +116,7 @@ function main() {
             echo "Usage: $0 [--help|-h]"
             exit 0
             ;;
-        --release)
+        --stable)
             BUILD_MODE='stable'
             ;;
         *)


### PR DESCRIPTION
### Reasons for making this change
The CI for creating new releases fails due to inconsistent use of the `--stable` vs `--release`.

Elsewhere in the code, and scripts, we use `--stable` rather than `--release`
