### PR TITLE
Remove upper boundary for dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,16 @@ authors = [
     {name = "Sindre Nistad", email = "snis@equinor.com"},
     {name = "Sebastian Vittersø", email = "svit@equinor.com"},
 ]
-requires-python = '>=3.11,<4.0'
+requires-python = '>=3.11'
 dependencies = [
-    'matplotlib (>=3.6.0,<4.0.0)',
-    'numpy (>=1.19.5,<2.0.0)',
-    'Pillow (>=10.3.0,<11.0.0)',
-    'scipy (>=1.10.0,<2.0.0)',
-    'xtgeo (>=4.3.3,<5.0.0)',
-    'PyYAML (>=6.0,<7.0)',
-    'gaussianfft (>=1.1.2,<2.0.0)',
-    'fmu-tools (>=1.21.0,<2.0.0)',
+    'matplotlib >= 3.6.0',
+    'numpy >= 1.19.5',
+    'Pillow >= 10.3.0',
+    'scipy >= 1.10.0',
+    'xtgeo >= 4.3.3',
+    'PyYAML >= 6.0',
+    'gaussianfft >= 1.1.2',
+    'fmu-tools >= 1.21.0',
 ]
 
 [project.scripts]
@@ -27,16 +27,16 @@ parse-truncation-rule-templates = "aps.toolbox.parse_truncation_rule_templates._
 
 [dependency-groups]
 dev = [
-    'pytest (>=6.2.5,<7.0.0)',
-    'graphviz (>=0.19.1,<1.0.0)',
-    'mypy (>=0.931,<1.0.0)',
-    'Flask (>=3.0.0,<4.0.0)',
-    'python-dotenv (>=0.19.2,<1.0.0)',
-    'typing-extensions (>=4.12.2,<5.0.0)',
+    'pytest',
+    'graphviz',
+    'mypy',
+    'Flask',
+    'python-dotenv',
+    'typing-extensions',
 ]
 docs = [
-    "mkdocs-material (>=9.6.20,<10.0.0)",
-    "mkdocs-git-revision-date-localized-plugin (>=1.4.7,<2.0.0)"
+    "mkdocs-material >= 9.6.20",
+    "mkdocs-git-revision-date-localized-plugin >= 1.4.7"
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <4.0"
+requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version < '3.12'",
@@ -45,28 +45,28 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fmu-tools", specifier = ">=1.21.0,<2.0.0" },
-    { name = "gaussianfft", specifier = ">=1.1.2,<2.0.0" },
-    { name = "matplotlib", specifier = ">=3.6.0,<4.0.0" },
-    { name = "numpy", specifier = ">=1.19.5,<2.0.0" },
-    { name = "pillow", specifier = ">=10.3.0,<11.0.0" },
-    { name = "pyyaml", specifier = ">=6.0,<7.0" },
-    { name = "scipy", specifier = ">=1.10.0,<2.0.0" },
-    { name = "xtgeo", specifier = ">=4.3.3,<5.0.0" },
+    { name = "fmu-tools", specifier = ">=1.21.0" },
+    { name = "gaussianfft", specifier = ">=1.1.2" },
+    { name = "matplotlib", specifier = ">=3.6.0" },
+    { name = "numpy", specifier = ">=1.19.5" },
+    { name = "pillow", specifier = ">=10.3.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "scipy", specifier = ">=1.10.0" },
+    { name = "xtgeo", specifier = ">=4.3.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "flask", specifier = ">=3.0.0,<4.0.0" },
-    { name = "graphviz", specifier = ">=0.19.1,<1.0.0" },
-    { name = "mypy", specifier = ">=0.931,<1.0.0" },
-    { name = "pytest", specifier = ">=6.2.5,<7.0.0" },
-    { name = "python-dotenv", specifier = ">=0.19.2,<1.0.0" },
-    { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
+    { name = "flask" },
+    { name = "graphviz" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
 ]
 docs = [
-    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7,<2.0.0" },
-    { name = "mkdocs-material", specifier = ">=9.6.20,<10.0.0" },
+    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.4.7" },
+    { name = "mkdocs-material", specifier = ">=9.6.20" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Reasons for making this change

It makes it har to resolve dependabot updates.
If there are known incompatibilities with some versions, we will specify limits.
