### PR TITLE
Ensure tests can be executed in a container again

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - './models/private:/private'
       - './models/project:/project'
       - './.git:/code/.git:ro' # Used by hatch-vcs to create _version.py
+      - './tests:/code/tests'
     env_file:
       - .env
 

--- a/mise.toml
+++ b/mise.toml
@@ -26,7 +26,10 @@ run = "uv run --no-project mkdocs serve"
 depends = ["dependencies:docs"]
 
 [tasks.build-containers]
-run = 'docker compose build --build-arg="RMS_IMAGE=$RMS_IMAGE" {{option(name="only", var=true)}}'
+usage = '''
+flag "--only <only>" help="Specify a single container to build"
+'''
+run = 'docker compose build --build-arg="RMS_IMAGE=$RMS_IMAGE" {{usage.only}}'
 env = { _.file = ".env" }
 
 [tasks."unit-test:python"]

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ env = { _.file = ".env" }
 
 [tasks."unit-test:python"]
 depends = ["build-containers --only api"]
-run = "docker compose run --rm api uv run pytest aps/tests"
+run = "docker compose run --rm api uv run pytest tests"
 
 [env]
 _.python.venv = { path = ".venv", create = false }


### PR DESCRIPTION
### Reasons for making this change

After 68e44e226e448e458f2e48e52aec141125e6f066, the script for running the tests was not updated as well.

On a related note; using `option` in a `mise` task is deprecated. It is recommended to migrate to `usage` instead.